### PR TITLE
Add lambda function tests

### DIFF
--- a/bcss_s3_to_lambda/lambda_function.py
+++ b/bcss_s3_to_lambda/lambda_function.py
@@ -50,6 +50,10 @@ def db_config():
     }
 
 
+def generate_batch_id():
+    return str(uuid.uuid4())
+
+
 def lambda_handler(_event: dict, _context: object) -> None:
     """
     AWS Lambda handler to process and send batch notifications.
@@ -61,13 +65,13 @@ def lambda_handler(_event: dict, _context: object) -> None:
     logger = initialise_logger()
     logger.info("Lambda function has started.")
 
-    # Initialize processors
-    batch_processor = BCSSNotifyBatchProcessor(db_config())
-
     # Generate unique batch ID
-    batch_id = str(uuid.uuid4())
+    batch_id = generate_batch_id()
     logger.debug("Generated batch ID: %s", batch_id)
 
+    # Initialize processors
+    batch_processor = BCSSNotifyBatchProcessor(batch_id, db_config())
+
     logger.info("Getting participants...")
-    participants = batch_processor.get_participants(batch_id)
+    participants = batch_processor.get_participants()
     logger.info("participants:\n%s", participants)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-import os
-import sys
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/bcss_notify_callback")

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,6 +1,0 @@
-import os
-import sys
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../bcss_s3_to_lambda")
-sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../bcss_notify_callback")

--- a/tests/unit/bcss_notify_callback/__init__.py
+++ b/tests/unit/bcss_notify_callback/__init__.py
@@ -1,6 +1,11 @@
 import os
 import sys
 
+# The bcss-notify-integration repo contains several modules called lambda_function.py
+# This is a pattern enforced by AWS Lambda, but it makes it difficult to import the 
+# correct module in tests as import order is not guaranteed.
+# To work around this, we remove any existing modules from the sys.modules cache
+# named "lambda_function" before importing the module we want to test.
 if "lambda_function" in sys.modules:
     del sys.modules["lambda_function"]
 

--- a/tests/unit/bcss_notify_callback/__init__.py
+++ b/tests/unit/bcss_notify_callback/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+if "lambda_function" in sys.modules:
+    del sys.modules["lambda_function"]
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../../bcss_notify_callback")

--- a/tests/unit/bcss_notify_callback/test_lambda_function.py
+++ b/tests/unit/bcss_notify_callback/test_lambda_function.py
@@ -110,7 +110,6 @@ def test_get_message_references_invalid_missing_message_reference_key(
 
 
 def test_get_statuses_from_communication_management_api_valid(
-    mock_get_message_references,
     mock_requests_get,
     example_batch_id,
     example_comms_management_response,
@@ -121,7 +120,8 @@ def test_get_statuses_from_communication_management_api_valid(
     mock_comms_management_response.json.return_value = example_comms_management_response
     mock_requests_get.return_value = mock_comms_management_response
 
-    mock_get_message_references.return_value = example_message_references
+    mock_get_message_references = MagicMock(return_value=example_message_references)
+    lf.get_message_references = mock_get_message_references
 
     response = lf.get_statuses_from_communication_management_api(example_batch_id)
     mock_requests_get.assert_called_once_with(

--- a/tests/unit/bcss_s3_to_lambda/__init__.py
+++ b/tests/unit/bcss_s3_to_lambda/__init__.py
@@ -1,6 +1,11 @@
 import os
 import sys
 
+# The bcss-notify-integration repo contains several modules called lambda_function.py
+# This is a pattern enforced by AWS Lambda, but it makes it difficult to import the 
+# correct module in tests as import order is not guaranteed.
+# To work around this, we remove any existing modules from the sys.modules cache
+# named "lambda_function" before importing the module we want to test.
 if "lambda_function" in sys.modules:
     del sys.modules["lambda_function"]
 

--- a/tests/unit/bcss_s3_to_lambda/__init__.py
+++ b/tests/unit/bcss_s3_to_lambda/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+if "lambda_function" in sys.modules:
+    del sys.modules["lambda_function"]
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../../bcss_s3_to_lambda")

--- a/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
@@ -1,11 +1,15 @@
 from unittest.mock import MagicMock, patch
-from lambda_function import lambda_handler, initialise_logger, secrets_client, get_secret, db_config
+from lambda_function import (
+        lambda_handler, initialise_logger, secrets_client, 
+        get_secret, db_config, generate_batch_id
+)
 import boto3
 import logging
 
 
+@patch("lambda_function.generate_batch_id", return_value="b3b3b3b3-b3b3-b3b3b3b3-b3b3b3b3b3b3")
 @patch("lambda_function.BCSSNotifyBatchProcessor", autospec=True)
-def test_lambda_handler(mock_bcss_notify_batch_processor, monkeypatch):
+def test_lambda_handler(mock_bcss_notify_batch_processor, generate_batch_id, monkeypatch):
     monkeypatch.setenv("host", "host")
     monkeypatch.setenv("port", "port")
     monkeypatch.setenv("sid", "sid")
@@ -16,7 +20,10 @@ def test_lambda_handler(mock_bcss_notify_batch_processor, monkeypatch):
 
     lambda_handler({}, {})
 
-    mock_bcss_notify_batch_processor.assert_called_once_with({"dsn": "host:port/sid", "user": "user", "password": "pass"})
+    mock_bcss_notify_batch_processor.assert_called_once_with(
+        "b3b3b3b3-b3b3-b3b3b3b3-b3b3b3b3b3b3",
+        {"dsn": "host:port/sid", "user": "user", "password": "pass"}
+    )
     mock_bcss_notify_batch_processor.return_value.get_participants.assert_called_once()
 
 

--- a/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, patch
+from lambda_function import lambda_handler, initialise_logger, secrets_client, get_secret, db_config
+import boto3
+import logging
+
+
+@patch("lambda_function.BCSSNotifyBatchProcessor", autospec=True)
+def test_lambda_handler(mock_bcss_notify_batch_processor, monkeypatch):
+    monkeypatch.setenv("host", "host")
+    monkeypatch.setenv("port", "port")
+    monkeypatch.setenv("sid", "sid")
+    secrets_client = MagicMock()
+    secrets_client.get_secret_value.return_value = {"SecretString": '{"username": "user", "password": "pass"}'}
+    boto3.client = MagicMock(return_value=secrets_client)
+    mock_bcss_notify_batch_processor.get_participants.return_value = [{"nhs_number": "1234567890"}]
+
+    lambda_handler({}, {})
+
+    mock_bcss_notify_batch_processor.assert_called_once_with({"dsn": "host:port/sid", "user": "user", "password": "pass"})
+    mock_bcss_notify_batch_processor.return_value.get_participants.assert_called_once()
+
+
+def test_initialise_logger():
+    mock_logger = MagicMock()
+    mock_stream_handler = MagicMock()
+    logging.getLogger = MagicMock(return_value=mock_logger)
+    logging.StreamHandler = MagicMock(return_value=mock_stream_handler)
+
+    logger = initialise_logger()
+    assert logger == mock_logger
+
+    mock_logger.setLevel.assert_called_once_with(logging.INFO)
+    mock_logger.addHandler.assert_any_call(mock_stream_handler)
+
+
+def test_secrets_client(monkeypatch):
+    boto3.client = MagicMock()
+    monkeypatch.setenv("region_name", "us-east-1")
+
+    assert secrets_client() == boto3.client("secretsmanager", region_name="us-east-1")
+
+
+def test_get_secret():
+    secrets_client = MagicMock()
+    secrets_client.get_secret_value.return_value = {"SecretString": '{"username": "user", "password": "pass"}'}
+    boto3.client = MagicMock(return_value=secrets_client)
+
+    assert get_secret("test") == {"username": "user", "password": "pass"}
+
+
+def test_db_config(monkeypatch):
+    monkeypatch.setenv("username", "user")
+    monkeypatch.setenv("password", "pass")
+    monkeypatch.setenv("host", "host")
+    monkeypatch.setenv("port", "port")
+    monkeypatch.setenv("sid", "sid")
+    config = db_config()
+    assert config == {"user": "user", "password": "pass", "dsn": "host:port/sid"}

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,12 +55,6 @@ def mock_requests_get():
 
 
 @pytest.fixture
-def mock_get_message_references():
-    with patch("lambda_function.get_message_references") as mock_get_message_references:
-        yield mock_get_message_references
-
-
-@pytest.fixture
 def mock_read_queue_to_dict():
     with patch("sql.read_queue_table_to_dict") as mock_read_queue_to_dict:
         yield mock_read_queue_to_dict


### PR DESCRIPTION
## More unit tests

- Adds unit tests for Batch Processor / Notify calling `lambda_handler` function
- Disambiguates the two lambda functions in the test suite. A hangover of opinionated serverless architecture when we have modules of the same name being imported.
- Small refactor of how we initialise the batch processor so that batch_id is passed to the construcutor