### PR TITLE
Ignore wrong import order linting rule

### DIFF
--- a/pylintrc.toml
+++ b/pylintrc.toml
@@ -416,6 +416,7 @@ disable = [
     "inconsistent-return-statements",
     "missing-timeout",
     "pointless-string-statement",
+    "wrong-import-order",
 ]
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
We often prefer alphabetical ordering. 
It's also hard to distinguish a 3rd party module from a core module without memorising the entire Python API.
We don't want to go back and fix commits for something so minor.