### PR TITLE
Schedule status check on successful message batch request 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,12 +29,12 @@ requests = "==2.32.3"
 tomlkit = "==0.13.2"
 urllib3 = "==2.3.0"
 boto3 = "*"
-pytest = "*"
 virtualenv = "*"
-pytest-cov = "*"
 
 [dev-packages]
 requests-mock = "*"
+pytest = "*"
+pytest-cov = "*"
 
 [requires]
 python_version = "3.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dd7992b7f0e438dce0d52e0b4840f5539738114412df8404b9d2b438f61f5aae"
+            "sha256": "0dae7b42bfd2a5862f8f17cd162bdc7a04b865d01c7e809bea035d71e2ff3fad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -27,20 +27,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:295648f887464ab74c5c301a44982df76f9ba39ebfc16be5b8f071ad1a81fe95",
-                "sha256:90fa5a91d7d7456219f0b7c4a93b38335dc5cf4613d885da4d4c1d099e04c6b7"
+                "sha256:56b4d1e084dbca43d5fdd070f633a84de61a6ce592655b4d239d263d1a0097fc",
+                "sha256:cf2e5e6d56efd5850db8ce3d9094132e4759cf2d4b5fd8200d69456bf61a20f3"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.13"
+            "version": "==1.37.14"
         },
         "botocore": {
             "hashes": [
-                "sha256:60dfb831c54eb466db9b91891a6c8a0c223626caa049969d5d42858ad1e7f8c7",
-                "sha256:aa417bac0f4d79533080e6e17c0509e149353aec83cfe7879597a7942f7f08d0"
+                "sha256:709a1796f436f8e378e52170e58501c1f3b5f2d1308238cf1d6a3bdba2e32851",
+                "sha256:b0adce3f0fb42b914eb05079f50cf368cb9cf9745fdd206bd91fe6ac67b29aca"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.37.13"
+            "version": "==1.37.14"
         },
         "certifi": {
             "hashes": [
@@ -232,78 +232,6 @@
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==0.4.6"
-        },
-        "coverage": {
-            "extras": [
-                "toml"
-            ],
-            "hashes": [
-                "sha256:056d3017ed67e7ddf266e6f57378ece543755a4c9231e997789ab3bd11392c94",
-                "sha256:0ce8cf59e09d31a4915ff4c3b94c6514af4c84b22c4cc8ad7c3c546a86150a92",
-                "sha256:104bf640f408f4e115b85110047c7f27377e1a8b7ba86f7db4fa47aa49dc9a8e",
-                "sha256:1393e5aa9441dafb0162c36c8506c648b89aea9565b31f6bfa351e66c11bcd82",
-                "sha256:1586ad158523f4133499a4f322b230e2cfef9cc724820dbd58595a5a236186f4",
-                "sha256:180e3fc68ee4dc5af8b33b6ca4e3bb8aa1abe25eedcb958ba5cff7123071af68",
-                "sha256:1b336d06af14f8da5b1f391e8dec03634daf54dfcb4d1c4fb6d04c09d83cef90",
-                "sha256:1c8fbce80b2b8bf135d105aa8f5b36eae0c57d702a1cc3ebdea2a6f03f6cdde5",
-                "sha256:2d673e3add00048215c2cc507f1228a7523fd8bf34f279ac98334c9b07bd2656",
-                "sha256:316f29cc3392fa3912493ee4c83afa4a0e2db04ff69600711f8c03997c39baaa",
-                "sha256:33c1394d8407e2771547583b66a85d07ed441ff8fae5a4adb4237ad39ece60db",
-                "sha256:37cbc7b0d93dfd133e33c7ec01123fbb90401dce174c3b6661d8d36fb1e30608",
-                "sha256:39abcacd1ed54e2c33c54bdc488b310e8ef6705833f7148b6eb9a547199d375d",
-                "sha256:3ab7090f04b12dc6469882ce81244572779d3a4b67eea1c96fb9ecc8c607ef39",
-                "sha256:3b0e6e54591ae0d7427def8a4d40fca99df6b899d10354bab73cd5609807261c",
-                "sha256:416e2a8845eaff288f97eaf76ab40367deafb9073ffc47bf2a583f26b05e5265",
-                "sha256:4545485fef7a8a2d8f30e6f79ce719eb154aab7e44217eb444c1d38239af2072",
-                "sha256:4c124025430249118d018dcedc8b7426f39373527c845093132196f2a483b6dd",
-                "sha256:4fbb7a0c3c21908520149d7751cf5b74eb9b38b54d62997b1e9b3ac19a8ee2fe",
-                "sha256:52fc89602cde411a4196c8c6894afb384f2125f34c031774f82a4f2608c59d7d",
-                "sha256:55143aa13c49491f5606f05b49ed88663446dce3a4d3c5d77baa4e36a16d3573",
-                "sha256:57f3bd0d29bf2bd9325c0ff9cc532a175110c4bf8f412c05b2405fd35745266d",
-                "sha256:5b2f144444879363ea8834cd7b6869d79ac796cb8f864b0cfdde50296cd95816",
-                "sha256:5efdeff5f353ed3352c04e6b318ab05c6ce9249c25ed3c2090c6e9cadda1e3b2",
-                "sha256:60e6347d1ed882b1159ffea172cb8466ee46c665af4ca397edbf10ff53e9ffaf",
-                "sha256:693d921621a0c8043bfdc61f7d4df5ea6d22165fe8b807cac21eb80dd94e4bbd",
-                "sha256:708f0a1105ef2b11c79ed54ed31f17e6325ac936501fc373f24be3e6a578146a",
-                "sha256:70f0925c4e2bfc965369f417e7cc72538fd1ba91639cf1e4ef4b1a6b50439b3b",
-                "sha256:7789e700f33f2b133adae582c9f437523cd5db8de845774988a58c360fc88253",
-                "sha256:7b6c96d69928a3a6767fab8dc1ce8a02cf0156836ccb1e820c7f45a423570d98",
-                "sha256:7d2a65876274acf544703e943c010b60bd79404e3623a1e5d52b64a6e2728de5",
-                "sha256:7f18d47641282664276977c604b5a261e51fefc2980f5271d547d706b06a837f",
-                "sha256:89078312f06237417adda7c021c33f80f7a6d2db8572a5f6c330d89b080061ce",
-                "sha256:8c938c6ae59be67ac19a7204e079efc94b38222cd7d0269f96e45e18cddeaa59",
-                "sha256:8e336b56301774ace6be0017ff85c3566c556d938359b61b840796a0202f805c",
-                "sha256:a0a207c87a9f743c8072d059b4711f8d13c456eb42dac778a7d2e5d4f3c253a7",
-                "sha256:a2454b12a3f12cc4698f3508912e6225ec63682e2ca5a96f80a2b93cef9e63f3",
-                "sha256:a538a23119d1e2e2ce077e902d02ea3d8e0641786ef6e0faf11ce82324743944",
-                "sha256:aa4dff57fc21a575672176d5ab0ef15a927199e775c5e8a3d75162ab2b0c7705",
-                "sha256:ad0edaa97cb983d9f2ff48cadddc3e1fb09f24aa558abeb4dc9a0dbacd12cbb4",
-                "sha256:ae8006772c6b0fa53c33747913473e064985dac4d65f77fd2fdc6474e7cd54e4",
-                "sha256:b0fac2088ec4aaeb5468b814bd3ff5e5978364bfbce5e567c44c9e2854469f6c",
-                "sha256:b3e212a894d8ae07fde2ca8b43d666a6d49bbbddb10da0f6a74ca7bd31f20054",
-                "sha256:b54a1ee4c6f1905a436cbaa04b26626d27925a41cbc3a337e2d3ff7038187f07",
-                "sha256:b667b91f4f714b17af2a18e220015c941d1cf8b07c17f2160033dbe1e64149f0",
-                "sha256:b8c36093aca722db73633cf2359026ed7782a239eb1c6db2abcff876012dc4cf",
-                "sha256:bb356e7ae7c2da13f404bf8f75be90f743c6df8d4607022e759f5d7d89fe83f8",
-                "sha256:bce730d484038e97f27ea2dbe5d392ec5c2261f28c319a3bb266f6b213650135",
-                "sha256:c075d167a6ec99b798c1fdf6e391a1d5a2d054caffe9593ba0f97e3df2c04f0e",
-                "sha256:c4e09534037933bf6eb31d804e72c52ec23219b32c1730f9152feabbd7499463",
-                "sha256:c5f8a5364fc37b2f172c26a038bc7ec4885f429de4a05fc10fdcb53fb5834c5c",
-                "sha256:cb203c0afffaf1a8f5b9659a013f8f16a1b2cad3a80a8733ceedc968c0cf4c57",
-                "sha256:cc41374d2f27d81d6558f8a24e5c114580ffefc197fd43eabd7058182f743322",
-                "sha256:cd879d4646055a573775a1cec863d00c9ff8c55860f8b17f6d8eee9140c06166",
-                "sha256:d013c07061751ae81861cae6ec3a4fe04e84781b11fd4b6b4201590234b25c7b",
-                "sha256:d8c7524779003d59948c51b4fcbf1ca4e27c26a7d75984f63488f3625c328b9b",
-                "sha256:d9710521f07f526de30ccdead67e6b236fe996d214e1a7fba8b36e2ba2cd8261",
-                "sha256:e1ffde1d6bc2a92f9c9207d1ad808550873748ac2d4d923c815b866baa343b3f",
-                "sha256:e7f559c36d5cdc448ee13e7e56ed7b6b5d44a40a511d584d388a0f5d940977ba",
-                "sha256:f2a1e18a85bd066c7c556d85277a7adf4651f259b2579113844835ba1a74aafd",
-                "sha256:f32b165bf6dfea0846a9c9c38b7e1d68f313956d60a15cde5d1709fddcaf3bee",
-                "sha256:f5a2f71d6a91238e7628f23538c26aa464d390cbdedf12ee2a7a0fb92a24482a",
-                "sha256:f81fe93dc1b8e5673f33443c0786c14b77e36f1025973b85e07c70353e46882b"
-            ],
-            "markers": "python_version >= '3.9'",
-            "version": "==7.7.0"
         },
         "cryptography": {
             "hashes": [
@@ -514,24 +442,6 @@
             "markers": "python_full_version >= '3.9.0'",
             "version": "==3.3.4"
         },
-        "pytest": {
-            "hashes": [
-                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
-                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==8.3.5"
-        },
-        "pytest-cov": {
-            "hashes": [
-                "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35",
-                "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9'",
-            "version": "==6.0.0"
-        },
         "python-dateutil": {
             "hashes": [
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
@@ -559,11 +469,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:199466a166ff664970d0ee145839f5582cb9bca7a0a3a2e795b6a9cb2308e9c6",
-                "sha256:43b4ee60e10b0d0ee98ad11918e114c70701bc6051662a9a675a0496c1a158f4"
+                "sha256:34750dcb17d046929f545dec9b8349fe42bf4ba13ddffee78428aec422dbfb73",
+                "sha256:4959b9ad482ada2ba2320c8f1a8d8481d4d8d668908a7a1b84d987375cd7f5bd"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==76.0.0"
+            "version": "==76.1.0"
         },
         "six": {
             "hashes": [
@@ -710,6 +620,78 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.4.1"
         },
+        "coverage": {
+            "extras": [
+                "toml"
+            ],
+            "hashes": [
+                "sha256:056d3017ed67e7ddf266e6f57378ece543755a4c9231e997789ab3bd11392c94",
+                "sha256:0ce8cf59e09d31a4915ff4c3b94c6514af4c84b22c4cc8ad7c3c546a86150a92",
+                "sha256:104bf640f408f4e115b85110047c7f27377e1a8b7ba86f7db4fa47aa49dc9a8e",
+                "sha256:1393e5aa9441dafb0162c36c8506c648b89aea9565b31f6bfa351e66c11bcd82",
+                "sha256:1586ad158523f4133499a4f322b230e2cfef9cc724820dbd58595a5a236186f4",
+                "sha256:180e3fc68ee4dc5af8b33b6ca4e3bb8aa1abe25eedcb958ba5cff7123071af68",
+                "sha256:1b336d06af14f8da5b1f391e8dec03634daf54dfcb4d1c4fb6d04c09d83cef90",
+                "sha256:1c8fbce80b2b8bf135d105aa8f5b36eae0c57d702a1cc3ebdea2a6f03f6cdde5",
+                "sha256:2d673e3add00048215c2cc507f1228a7523fd8bf34f279ac98334c9b07bd2656",
+                "sha256:316f29cc3392fa3912493ee4c83afa4a0e2db04ff69600711f8c03997c39baaa",
+                "sha256:33c1394d8407e2771547583b66a85d07ed441ff8fae5a4adb4237ad39ece60db",
+                "sha256:37cbc7b0d93dfd133e33c7ec01123fbb90401dce174c3b6661d8d36fb1e30608",
+                "sha256:39abcacd1ed54e2c33c54bdc488b310e8ef6705833f7148b6eb9a547199d375d",
+                "sha256:3ab7090f04b12dc6469882ce81244572779d3a4b67eea1c96fb9ecc8c607ef39",
+                "sha256:3b0e6e54591ae0d7427def8a4d40fca99df6b899d10354bab73cd5609807261c",
+                "sha256:416e2a8845eaff288f97eaf76ab40367deafb9073ffc47bf2a583f26b05e5265",
+                "sha256:4545485fef7a8a2d8f30e6f79ce719eb154aab7e44217eb444c1d38239af2072",
+                "sha256:4c124025430249118d018dcedc8b7426f39373527c845093132196f2a483b6dd",
+                "sha256:4fbb7a0c3c21908520149d7751cf5b74eb9b38b54d62997b1e9b3ac19a8ee2fe",
+                "sha256:52fc89602cde411a4196c8c6894afb384f2125f34c031774f82a4f2608c59d7d",
+                "sha256:55143aa13c49491f5606f05b49ed88663446dce3a4d3c5d77baa4e36a16d3573",
+                "sha256:57f3bd0d29bf2bd9325c0ff9cc532a175110c4bf8f412c05b2405fd35745266d",
+                "sha256:5b2f144444879363ea8834cd7b6869d79ac796cb8f864b0cfdde50296cd95816",
+                "sha256:5efdeff5f353ed3352c04e6b318ab05c6ce9249c25ed3c2090c6e9cadda1e3b2",
+                "sha256:60e6347d1ed882b1159ffea172cb8466ee46c665af4ca397edbf10ff53e9ffaf",
+                "sha256:693d921621a0c8043bfdc61f7d4df5ea6d22165fe8b807cac21eb80dd94e4bbd",
+                "sha256:708f0a1105ef2b11c79ed54ed31f17e6325ac936501fc373f24be3e6a578146a",
+                "sha256:70f0925c4e2bfc965369f417e7cc72538fd1ba91639cf1e4ef4b1a6b50439b3b",
+                "sha256:7789e700f33f2b133adae582c9f437523cd5db8de845774988a58c360fc88253",
+                "sha256:7b6c96d69928a3a6767fab8dc1ce8a02cf0156836ccb1e820c7f45a423570d98",
+                "sha256:7d2a65876274acf544703e943c010b60bd79404e3623a1e5d52b64a6e2728de5",
+                "sha256:7f18d47641282664276977c604b5a261e51fefc2980f5271d547d706b06a837f",
+                "sha256:89078312f06237417adda7c021c33f80f7a6d2db8572a5f6c330d89b080061ce",
+                "sha256:8c938c6ae59be67ac19a7204e079efc94b38222cd7d0269f96e45e18cddeaa59",
+                "sha256:8e336b56301774ace6be0017ff85c3566c556d938359b61b840796a0202f805c",
+                "sha256:a0a207c87a9f743c8072d059b4711f8d13c456eb42dac778a7d2e5d4f3c253a7",
+                "sha256:a2454b12a3f12cc4698f3508912e6225ec63682e2ca5a96f80a2b93cef9e63f3",
+                "sha256:a538a23119d1e2e2ce077e902d02ea3d8e0641786ef6e0faf11ce82324743944",
+                "sha256:aa4dff57fc21a575672176d5ab0ef15a927199e775c5e8a3d75162ab2b0c7705",
+                "sha256:ad0edaa97cb983d9f2ff48cadddc3e1fb09f24aa558abeb4dc9a0dbacd12cbb4",
+                "sha256:ae8006772c6b0fa53c33747913473e064985dac4d65f77fd2fdc6474e7cd54e4",
+                "sha256:b0fac2088ec4aaeb5468b814bd3ff5e5978364bfbce5e567c44c9e2854469f6c",
+                "sha256:b3e212a894d8ae07fde2ca8b43d666a6d49bbbddb10da0f6a74ca7bd31f20054",
+                "sha256:b54a1ee4c6f1905a436cbaa04b26626d27925a41cbc3a337e2d3ff7038187f07",
+                "sha256:b667b91f4f714b17af2a18e220015c941d1cf8b07c17f2160033dbe1e64149f0",
+                "sha256:b8c36093aca722db73633cf2359026ed7782a239eb1c6db2abcff876012dc4cf",
+                "sha256:bb356e7ae7c2da13f404bf8f75be90f743c6df8d4607022e759f5d7d89fe83f8",
+                "sha256:bce730d484038e97f27ea2dbe5d392ec5c2261f28c319a3bb266f6b213650135",
+                "sha256:c075d167a6ec99b798c1fdf6e391a1d5a2d054caffe9593ba0f97e3df2c04f0e",
+                "sha256:c4e09534037933bf6eb31d804e72c52ec23219b32c1730f9152feabbd7499463",
+                "sha256:c5f8a5364fc37b2f172c26a038bc7ec4885f429de4a05fc10fdcb53fb5834c5c",
+                "sha256:cb203c0afffaf1a8f5b9659a013f8f16a1b2cad3a80a8733ceedc968c0cf4c57",
+                "sha256:cc41374d2f27d81d6558f8a24e5c114580ffefc197fd43eabd7058182f743322",
+                "sha256:cd879d4646055a573775a1cec863d00c9ff8c55860f8b17f6d8eee9140c06166",
+                "sha256:d013c07061751ae81861cae6ec3a4fe04e84781b11fd4b6b4201590234b25c7b",
+                "sha256:d8c7524779003d59948c51b4fcbf1ca4e27c26a7d75984f63488f3625c328b9b",
+                "sha256:d9710521f07f526de30ccdead67e6b236fe996d214e1a7fba8b36e2ba2cd8261",
+                "sha256:e1ffde1d6bc2a92f9c9207d1ad808550873748ac2d4d923c815b866baa343b3f",
+                "sha256:e7f559c36d5cdc448ee13e7e56ed7b6b5d44a40a511d584d388a0f5d940977ba",
+                "sha256:f2a1e18a85bd066c7c556d85277a7adf4651f259b2579113844835ba1a74aafd",
+                "sha256:f32b165bf6dfea0846a9c9c38b7e1d68f313956d60a15cde5d1709fddcaf3bee",
+                "sha256:f5a2f71d6a91238e7628f23538c26aa464d390cbdedf12ee2a7a0fb92a24482a",
+                "sha256:f81fe93dc1b8e5673f33443c0786c14b77e36f1025973b85e07c70353e46882b"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==7.7.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
@@ -718,6 +700,48 @@
             "index": "pypi",
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==24.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820",
+                "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.5"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35",
+                "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.0.0"
         },
         "requests": {
             "hashes": [

--- a/bcss_s3_to_lambda/lambda_function.py
+++ b/bcss_s3_to_lambda/lambda_function.py
@@ -8,6 +8,7 @@ import boto3
 
 from batch_processor import BatchProcessor
 from communication_management import CommunicationManagement
+from scheduler import Scheduler
 
 
 def initialise_logger() -> logging.Logger:
@@ -85,5 +86,6 @@ def lambda_handler(_event: dict, _context: object) -> None:
     if response.status_code == 201:
         logger.info("Batch message sent successfully.")
         batch_processor.mark_batch_as_sent(recipients)
+        Scheduler(batch_id).schedule_status_check(720)
     else:
         logger.error("Failed to send batch message. Status code: %s", response.status_code)

--- a/bcss_s3_to_lambda/scheduler.py
+++ b/bcss_s3_to_lambda/scheduler.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import os
 import boto3
 
 
@@ -16,8 +17,8 @@ class Scheduler:
     def schedule_batch_processor_retry(self, minutes_from_now: int):
         name = "lambda_batch_processor_retry"
         target = {
-            "RoleArn": "<ROLE_ARN>",
-            "Arn": "<LAMBDA_ARN>",
+            "RoleArn": os.getenv("LAMBDA_BATCH_PROCESSOR_ROLE_ARN"),
+            "Arn": os.getenv("LAMBDA_BATCH_PROCESSOR_ARN"),
             "Input": self.payload()
         }
         logging.info(
@@ -29,8 +30,8 @@ class Scheduler:
     def schedule_status_check(self, minutes_from_now: int):
         name = "lambda_status_check"
         target = {
-            "RoleArn": "<ROLE_ARN>",
-            "Arn": "<LAMBDA_ARN>",
+            "RoleArn": os.getenv("LAMBDA_STATUS_CHECK_ROLE_ARN"),
+            "Arn": os.getenv("LAMBDA_STATUS_CHECK_ARN"),
             "Input": self.payload()
         }
 

--- a/bcss_s3_to_lambda/scheduler.py
+++ b/bcss_s3_to_lambda/scheduler.py
@@ -1,0 +1,36 @@
+import boto3
+import json
+
+
+class Scheduler:
+    def __init__(self):
+        self.scheduler = boto3.client("scheduler")
+        self.flex_window = {"Mode": "OFF"}
+
+    def schedule_batch_processor_retry(self, batch_id, schedule_expression):
+        name = "lambda_batch_processor_retry"
+        target = {
+            "RoleArn": "<ROLE_ARN>",
+            "Arn": "<LAMBDA_ARN>",
+            "Input": self.payload(batch_id)
+        }
+        self.create_schedule(name, schedule_expression, target)
+
+    def schedule_status_check(self, batch_id, schedule_expression):
+        name = "lambda_status_check"
+        target = {
+            "RoleArn": "<ROLE_ARN>",
+            "Arn": "<LAMBDA_ARN>",
+            "Input": self.payload(batch_id)
+        }
+        self.create_schedule(name, schedule_expression, target)
+
+    def create_schedule(self, name, schedule_expression, target):
+        self.scheduler.create_schedule(
+            Name=name,
+            ScheduleExpression=schedule_expression,
+            Target=target,
+            FlexibleTimeWindow=self.flex_window)
+
+    def payload(self, batch_id):
+        return json.dumps({"batch_id": batch_id})

--- a/bcss_s3_to_lambda/scheduler.py
+++ b/bcss_s3_to_lambda/scheduler.py
@@ -6,6 +6,7 @@ import boto3
 
 
 class Scheduler:
+    MAX_RETRIES = 5
     SCHEDULE_FORMAT = "at(%Y-%m-%dT%H:%M:%S)"
 
     def __init__(self, batch_id: str, retries: int = 0):
@@ -42,10 +43,10 @@ class Scheduler:
         self.create_schedule(name, minutes_from_now, target)
 
     def create_schedule(self, name: str, minutes_from_now: int, target: dict):
-        if self.retries > 5:
+        if self.retries > self.MAX_RETRIES:
             return
 
-        scheduled_at = Scheduler.schedule_time(minutes_from_now * self.retries)
+        scheduled_at = Scheduler.schedule_time(minutes_from_now)
 
         self.scheduler.create_schedule(
             Name=name,

--- a/bcss_s3_to_lambda/scheduler.py
+++ b/bcss_s3_to_lambda/scheduler.py
@@ -1,5 +1,6 @@
-import json
 import datetime
+import json
+import logging
 import boto3
 
 
@@ -19,6 +20,10 @@ class Scheduler:
             "Arn": "<LAMBDA_ARN>",
             "Input": self.payload()
         }
+        logging.info(
+            "Scheduling batch processor retry. batch_id: %s, retries: %s",
+            self.batch_id, self.retries
+        )
         self.create_schedule(name, minutes_from_now, target)
 
     def schedule_status_check(self, minutes_from_now: int):
@@ -28,6 +33,11 @@ class Scheduler:
             "Arn": "<LAMBDA_ARN>",
             "Input": self.payload()
         }
+
+        logging.info(
+            "Scheduling status check. batch_id: %s, retries: %s",
+            self.batch_id, self.retries
+        )
         self.create_schedule(name, minutes_from_now, target)
 
     def create_schedule(self, name: str, minutes_from_now: int, target: dict):

--- a/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
@@ -10,9 +10,10 @@ import logging
 
 
 @patch("lambda_function.generate_batch_id", return_value="b3b3b3b3-b3b3-b3b3b3b3-b3b3b3b3b3b3")
+@patch("lambda_function.Scheduler", autospec=True)
 @patch("lambda_function.CommunicationManagement", autospec=True)
 @patch("lambda_function.BatchProcessor", autospec=True)
-def test_lambda_handler(mock_batch_processor, mock_communication_management, generate_batch_id, monkeypatch):
+def test_lambda_handler(mock_batch_processor, mock_communication_management, mock_scheduler, generate_batch_id, monkeypatch):
     monkeypatch.setenv("host", "host")
     monkeypatch.setenv("port", "port")
     monkeypatch.setenv("sid", "sid")
@@ -46,6 +47,7 @@ def test_lambda_handler(mock_batch_processor, mock_communication_management, gen
         [recipient]
     )
     mock_batch_processor.return_value.mark_batch_as_sent.assert_called_once_with([recipient])
+    mock_scheduler.return_value.schedule_status_check.assert_called_once()
 
 
 def test_initialise_logger():

--- a/tests/unit/bcss_s3_to_lambda/test_scheduler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_scheduler.py
@@ -1,0 +1,50 @@
+from unittest.mock import patch
+from scheduler import Scheduler
+
+
+@patch("boto3.client")
+class TestScheduler:
+    def test_schedule_batch_processor_retry(self, mock_boto3_scheduler):
+        subject = Scheduler()
+        subject.schedule_batch_processor_retry("123", "rate(5 minutes)")
+
+        mock_boto3_scheduler.return_value.create_schedule.assert_called_once_with(
+            Name="lambda_batch_processor_retry",
+            ScheduleExpression="rate(5 minutes)",
+            Target={
+                "RoleArn": "<ROLE_ARN>",
+                "Arn": "<LAMBDA_ARN>",
+                "Input": '{"batch_id": "123"}'
+            },
+            FlexibleTimeWindow={"Mode": "OFF"}
+        )
+
+    def test_schedule_status_check(self, mock_boto3_scheduler):
+        subject = Scheduler()
+        subject.schedule_status_check("123", "rate(5 minutes)")
+
+        mock_boto3_scheduler.return_value.create_schedule.assert_called_once_with(
+            Name="lambda_status_check",
+            ScheduleExpression="rate(5 minutes)",
+            Target={
+                "RoleArn": "<ROLE_ARN>",
+                "Arn": "<LAMBDA_ARN>",
+                "Input": '{"batch_id": "123"}'
+            },
+            FlexibleTimeWindow={"Mode": "OFF"}
+        )
+
+    def test_create_schedule(self, mock_boto3_scheduler):
+        subject = Scheduler()
+        subject.create_schedule(
+            "name",
+            "rate(5 minutes)",
+            {"RoleArn": "role", "Arn": "arn", "Input": "input"},
+        )
+
+        mock_boto3_scheduler.return_value.create_schedule.assert_called_once_with(
+            Name="name",
+            ScheduleExpression="rate(5 minutes)",
+            Target={"RoleArn": "role", "Arn": "arn", "Input": "input"},
+            FlexibleTimeWindow={"Mode": "OFF"}
+        )

--- a/tests/unit/bcss_s3_to_lambda/test_scheduler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_scheduler.py
@@ -10,6 +10,7 @@ mock_arns = {
     "LAMBDA_STATUS_CHECK_ARN": "<STATUS_CHECK_LAMBDA_ARN>",
 }
 
+
 @patch.dict(os.environ, mock_arns)
 @patch("boto3.client")
 @patch.object(Scheduler, "now", return_value=datetime.datetime(2025, 3, 18, 12, 35, 22))
@@ -79,7 +80,7 @@ class TestScheduler:
 
         mock_boto3_scheduler.return_value.create_schedule.assert_called_once_with(
             Name="name",
-            ScheduleExpression="at(2025-03-18T13:05:22)",
+            ScheduleExpression="at(2025-03-18T12:45:22)",
             Target={"RoleArn": "role", "Arn": "arn", "Input": "input"},
             FlexibleTimeWindow={"Mode": "OFF"}
         )

--- a/tests/unit/bcss_s3_to_lambda/test_scheduler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_scheduler.py
@@ -1,8 +1,16 @@
 import datetime
+import os
 from unittest.mock import patch, Mock
 from scheduler import Scheduler
 
+mock_arns = {
+    "LAMBDA_BATCH_PROCESSOR_ROLE_ARN": "<BATCH_PROCESSOR_ROLE_ARN>",
+    "LAMBDA_BATCH_PROCESSOR_ARN": "<BATCH_PROCESSOR_LAMBDA_ARN>",
+    "LAMBDA_STATUS_CHECK_ROLE_ARN": "<STATUS_CHECK_ROLE_ARN>",
+    "LAMBDA_STATUS_CHECK_ARN": "<STATUS_CHECK_LAMBDA_ARN>",
+}
 
+@patch.dict(os.environ, mock_arns)
 @patch("boto3.client")
 @patch.object(Scheduler, "now", return_value=datetime.datetime(2025, 3, 18, 12, 35, 22))
 class TestScheduler:
@@ -14,8 +22,8 @@ class TestScheduler:
             Name="lambda_batch_processor_retry",
             ScheduleExpression="at(2025-03-18T12:40:22)",
             Target={
-                "RoleArn": "<ROLE_ARN>",
-                "Arn": "<LAMBDA_ARN>",
+                "RoleArn": "<BATCH_PROCESSOR_ROLE_ARN>",
+                "Arn": "<BATCH_PROCESSOR_LAMBDA_ARN>",
                 "Input": '{"batch_id": "123", "retries": 1}'
             },
             FlexibleTimeWindow={"Mode": "OFF"}
@@ -29,8 +37,8 @@ class TestScheduler:
             Name="lambda_status_check",
             ScheduleExpression="at(2025-03-18T12:40:22)",
             Target={
-                "RoleArn": "<ROLE_ARN>",
-                "Arn": "<LAMBDA_ARN>",
+                "RoleArn": "<STATUS_CHECK_ROLE_ARN>",
+                "Arn": "<STATUS_CHECK_LAMBDA_ARN>",
                 "Input": '{"batch_id": "123", "retries": 1}'
             },
             FlexibleTimeWindow={"Mode": "OFF"}


### PR DESCRIPTION
We need a way to schedule status checks from the batch processing lambda. (ignore the branch name)

We can use the [boto3 client scheduler to schedule execution of a lambda](https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-targets-templated.html). 

- Adds a scheduler class which calls the boto3 client accordingly
- Scheduler also handles status check lambda scheduling although the implementation/integration is out of scope for this PR
- Role and Lambda ARNs should be present in the env. TBC if this is the right approach.
- Retries are hardwired to 5 cycles, this might be overkill, we might also want to configure per call.