### PR TITLE
Make individual db updates

### DIFF
--- a/bcss_s3_to_lambda/batch_processor.py
+++ b/bcss_s3_to_lambda/batch_processor.py
@@ -38,16 +38,15 @@ class BatchProcessor:
             logging.error({"error": str(e)})
 
         for recipient in recipients:
-            recipient.message_reference = self.generate_message_reference()
-            recipient.message_status = "REQUESTED"
-            self.db.update_recipient(recipient)
+            recipient.message_id = self.generate_message_reference()
+            self.db.update_message_id(recipient)
 
         return recipients
 
     def mark_batch_as_sent(self, recipients):
         for recipient in recipients:
             recipient.message_status = "SENT"
-            self.db.update_recipient(recipient)
+            self.db.update_message_status(recipient)
 
     @staticmethod
     def generate_message_reference():

--- a/bcss_s3_to_lambda/batch_processor.py
+++ b/bcss_s3_to_lambda/batch_processor.py
@@ -9,6 +9,8 @@ logging.basicConfig(
 
 
 class BatchProcessor:
+    SENDING_STATUS = "SENDING"
+
     def __init__(self, batch_id: str, db_config: dict):
         self.batch_id = batch_id
         self.db = OracleDatabase(db_config["dsn"], db_config["user"], db_config["password"])
@@ -45,7 +47,7 @@ class BatchProcessor:
 
     def mark_batch_as_sent(self, recipients):
         for recipient in recipients:
-            recipient.message_status = "SENT"
+            recipient.message_status = self.SENDING_STATUS
             self.db.update_message_status(recipient)
 
     @staticmethod

--- a/tests/unit/bcss_s3_to_lambda/test_batch_processor.py
+++ b/tests/unit/bcss_s3_to_lambda/test_batch_processor.py
@@ -25,7 +25,10 @@ def plan_id():
 
 @pytest.fixture
 def recipients():
-    return [Recipient(("0000000000",)), Recipient(("1111111111",))]
+    return [
+        Recipient(("0000000000", None, None, None, "REQUESTED")),
+        Recipient(("1111111111", None, None, None, "REQUESTED")),
+    ]
 
 
 @patch("batch_processor.OracleDatabase", autospec=True)
@@ -41,11 +44,11 @@ class TestBatchProcessor:
         assert len(recipients) == 2
 
         assert recipients[0].nhs_number == "0000000000"
-        assert recipients[0].message_reference == "message_reference_0"
+        assert recipients[0].message_id == "message_reference_0"
         assert recipients[0].message_status == "REQUESTED"
 
         assert recipients[1].nhs_number == "1111111111"
-        assert recipients[1].message_reference == "message_reference_1"
+        assert recipients[1].message_id == "message_reference_1"
         assert recipients[1].message_status == "REQUESTED"
 
     def test_null_recipients(self, mock_oracle_database, db_config, batch_id):

--- a/tests/unit/bcss_s3_to_lambda/test_batch_processor.py
+++ b/tests/unit/bcss_s3_to_lambda/test_batch_processor.py
@@ -89,3 +89,18 @@ class TestBatchProcessor:
 
         assert str(exc_info.value) == "Failed to fetch routing plan ID."
         assert mock_fetch_routing_plan_id.call_count == 1
+
+    def test_mark_batch_as_sent(self, mock_oracle_database, db_config, recipients):
+        subject = BatchProcessor(batch_id, db_config)
+
+        mock_update_message_status = subject.db.update_message_status
+
+        subject.mark_batch_as_sent(recipients)
+
+        assert mock_update_message_status.call_count == 2
+        assert recipients[0].message_status == "SENDING"
+        assert recipients[1].message_status == "SENDING"
+        assert mock_update_message_status.call_args_list == [
+            ((recipients[0],),),
+            ((recipients[1],),),
+        ]

--- a/tests/unit/bcss_s3_to_lambda/test_oracle_database.py
+++ b/tests/unit/bcss_s3_to_lambda/test_oracle_database.py
@@ -77,3 +77,31 @@ class TestOracleDatabase(unittest.TestCase):
         assert isinstance(recipients[1], Recipient)
         assert recipients[1].nhs_number == "2222222222"
         assert recipients[1].message_id == "message_reference_2"
+
+    def test_update_message_id(self, mock_oracledb):
+        database = OracleDatabase(**db_config())
+        recipient = Recipient(("1111111111", "message_reference_1"))
+
+        mock_cursor = database.cursor().__enter__()
+
+        database.update_message_id(recipient)
+
+        mock_cursor.execute.assert_called_with(
+            "UPDATE v_notify_message_queue SET message_id = :message_id WHERE nhs_number = :nhs_number",
+            {'message_id': recipient.message_id, 'nhs_number': recipient.nhs_number}
+        )
+        database.connection.commit.assert_called_once()
+
+    def test_update_message_status(self, mock_oracledb):
+        database = OracleDatabase(**db_config())
+        recipient = Recipient(("1111111111", "message_reference_1"))
+
+        mock_cursor = database.cursor().__enter__()
+
+        database.update_message_status(recipient)
+
+        mock_cursor.execute.assert_called_with(
+            "UPDATE v_notify_message_queue SET message_status = :message_status WHERE nhs_number = :nhs_number",
+            {'message_status': recipient.message_status, 'nhs_number': recipient.nhs_number}
+        )
+        database.connection.commit.assert_called_once()


### PR DESCRIPTION
We need to perform `message_id` and `message_status` updates independently.

The main reason for this is that the Oracle stored procedure `f_get_next_batch` automatically sets a message status of `REQUESTED` on all rows in the batch which are populated into the `v_notify_message_queue` view.

We then need to populate the `message_id` for each row in this view as Oracle cannot generate the UUID needed for a NHS Notify message reference.

On a successful call to the NHS Notify API, we then set `message_status` to `SENDING` for each row on the `v_notify_message_queue`

See https://screening-discovery.slack.com/archives/C08ADLP42UT/p1742292567616869 for full discussion

### Changes:

- Adds 2 different update functions on the `OracleDatabase` class
- Adds `SENDING` as the message status we us on successful request.
- Firms up some tests around these changes.