### PR TITLE
Remove unnecessary logging format configuration

### DIFF
--- a/bcss_notify_callback/lambda_function.py
+++ b/bcss_notify_callback/lambda_function.py
@@ -10,11 +10,6 @@ import oracle_connection as db
 from patients_to_update import patient_to_update
 
 
-logging.basicConfig(
-    format="{asctime} - {levelname} - {message}", style="{", datefmt="%Y-%m-%d %H:%M:%S"
-)
-
-
 def generate_hmac_signature(secret: str, body: str) -> str:
     """Generate HMAC-SHA256 signature for request body."""
     return hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()

--- a/bcss_s3_to_lambda/batch_processor.py
+++ b/bcss_s3_to_lambda/batch_processor.py
@@ -3,10 +3,6 @@ import uuid
 import oracledb
 from oracle_database import OracleDatabase, DatabaseConnectionError, DatabaseFetchError
 
-logging.basicConfig(
-    format="{asctime} - {levelname} - {message}", style="{", datefmt="%Y-%m-%d %H:%M:%S"
-)
-
 
 class BatchProcessor:
     def __init__(self, batch_id: str, db_config: dict):

--- a/bcss_s3_to_lambda/oracle_database.py
+++ b/bcss_s3_to_lambda/oracle_database.py
@@ -5,10 +5,6 @@ import oracledb
 
 from recipient import Recipient
 
-logging.basicConfig(
-    format="{asctime} - {levelname} - {message}", style="{", datefmt="%Y-%m-%d %H:%M:%S"
-)
-
 
 class DatabaseConnectionError(Exception):
     """Exception raised when an error occurs connecting to the database."""

--- a/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
+++ b/tests/unit/bcss_s3_to_lambda/test_lambda_handler.py
@@ -1,8 +1,5 @@
 from unittest.mock import Mock, patch
-from lambda_function import (
-        lambda_handler, initialise_logger, secrets_client,
-        get_secret, db_config
-)
+from lambda_function import lambda_handler, secrets_client, get_secret, db_config
 from recipient import Recipient
 
 import boto3
@@ -46,19 +43,6 @@ def test_lambda_handler(mock_batch_processor, mock_communication_management, gen
         [recipient]
     )
     mock_batch_processor.return_value.mark_batch_as_sent.assert_called_once_with([recipient])
-
-
-def test_initialise_logger():
-    mock_logger = Mock()
-    mock_stream_handler = Mock()
-    logging.getLogger = Mock(return_value=mock_logger)
-    logging.StreamHandler = Mock(return_value=mock_stream_handler)
-
-    logger = initialise_logger()
-    assert logger == mock_logger
-
-    mock_logger.setLevel.assert_called_once_with(logging.INFO)
-    mock_logger.addHandler.assert_any_call(mock_stream_handler)
 
 
 def test_secrets_client(monkeypatch):


### PR DESCRIPTION
It's reapeated everywhere and no-one knows why. We can adopt a universal format should we need one.