### PR TITLE
Remove normalizer binary

### DIFF
--- a/bcss_s3_to_lambda/bin/normalizer
+++ b/bcss_s3_to_lambda/bin/normalizer
@@ -1,8 +1,0 @@
-#!/opt/homebrew/opt/python@3.12/bin/python3.12
-# -*- coding: utf-8 -*-
-import re
-import sys
-from charset_normalizer.cli import cli_detect
-if __name__ == '__main__':
-    sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
-    sys.exit(cli_detect())


### PR DESCRIPTION
This homebrew artefact should be in `.gitignore` if needed for local development.