### PR TITLE
Update message status

### DIFF
--- a/message_status_handler/database.py
+++ b/message_status_handler/database.py
@@ -1,0 +1,69 @@
+from contextlib import contextmanager
+import boto3
+import json
+import logging
+import oracledb
+import os
+
+
+class DatabaseConnectionError(Exception):
+    """Raised when there is an error connecting to the database"""
+
+
+client = None
+
+
+@contextmanager
+def connection():
+    try:
+        conn = oracledb.connect(**connection_params())
+        try:
+            yield conn
+        finally:
+            conn.close()
+    except oracledb.Error as e:
+        logging.error("Error Connecting to Database: %s", e)
+        raise DatabaseConnectionError(f"Error Connecting to Database: {str(e)}")
+
+
+@contextmanager
+def cursor():
+    cursor = None
+    try:
+        with connection() as conn:
+            cursor = conn.cursor()
+
+            yield cursor
+
+    finally:
+        cursor.close()
+
+
+def connection_params() -> dict:
+    secret = get_secret()
+    db_user: str = secret["username"]
+    db_password: str = secret["password"]
+    host: str = os.getenv("bcss_host", "")
+    port: str = os.getenv("port", "1521")
+    sid: str = os.getenv("sid", "")
+    dsn_tns = f"{host}:{port}/{sid}"
+
+    return {"user": db_user, "password": db_password, "dsn": dsn_tns}
+
+
+def get_secret() -> dict:
+    secret_name = os.getenv("bcss_secret_name")
+    secret_str = get_client().get_secret_value(
+        SecretId=secret_name)["SecretString"]
+    return json.loads(secret_str)
+
+
+def get_client():
+    global client
+    if not client:
+        client = boto3.client(
+            service_name="secretsmanager",
+            region_name=os.getenv("region_name")
+        )
+
+    return client

--- a/message_status_handler/database.py
+++ b/message_status_handler/database.py
@@ -10,7 +10,7 @@ class DatabaseConnectionError(Exception):
     """Raised when there is an error connecting to the database"""
 
 
-client = None
+client = None # pylint: disable=invalid-name
 
 
 @contextmanager
@@ -23,20 +23,20 @@ def connection():
             conn.close()
     except oracledb.Error as e:
         logging.error("Error Connecting to Database: %s", e)
-        raise DatabaseConnectionError(f"Error Connecting to Database: {str(e)}")
+        raise DatabaseConnectionError(f"Error Connecting to Database: {str(e)}") from e
 
 
 @contextmanager
 def cursor():
-    cursor = None
+    cur = None
     try:
         with connection() as conn:
-            cursor = conn.cursor()
+            cur = conn.cursor()
 
-            yield cursor
+            yield cur
 
     finally:
-        cursor.close()
+        cur.close()
 
 
 def connection_params() -> dict:
@@ -59,7 +59,7 @@ def get_secret() -> dict:
 
 
 def get_client():
-    global client
+    global client # pylint: disable=global-statement
     if not client:
         client = boto3.client(
             service_name="secretsmanager",

--- a/message_status_handler/message_status_recorder.py
+++ b/message_status_handler/message_status_recorder.py
@@ -1,0 +1,34 @@
+import database
+
+
+def record_message_statuses(batch_id: str, json_data: dict):
+    response_codes = []
+    message_references = [item['message_reference'] for item in json_data['data']]
+
+    with database.cursor() as cursor:
+        for message_reference in message_references:
+            response_codes.append(update_message_status(cursor, batch_id, message_reference))
+
+    return response_codes
+
+
+def update_message_status(cursor, batch_id: str, message_reference: str):
+    response_code = 1
+    var = cursor.var(int)
+
+    cursor.execute(
+        """
+            begin
+                :out_val := pkg_notify_wrap.f_update_message_status(:in_val1, :in_val2, :in_val3);
+            end;
+        """,
+        {
+            "in_val1": batch_id,
+            "in_val2": message_reference,
+            "in_val3": "read",
+            "out_val": var,
+        },
+    )
+    response_code = var.getvalue()
+
+    return response_code

--- a/tests/unit/message_status_handler/test_database.py
+++ b/tests/unit/message_status_handler/test_database.py
@@ -1,0 +1,51 @@
+import database
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture
+def mocked_env(monkeypatch):
+    monkeypatch.setenv("bcss_host", "test_host")
+    monkeypatch.setenv("port", "1521")
+    monkeypatch.setenv("sid", "test_sid")
+    monkeypatch.setenv("bcss_secret_name", "test_secret")
+    monkeypatch.setenv("region_name", "uk-west-1")
+
+
+@pytest.fixture
+def mock_boto3_client(mocked_env):
+    with patch("boto3.client") as mock_boto3_client:
+        mock_boto3_client.return_value.get_secret_value.return_value={"SecretString": '{"username": "test", "password": "test"}'}
+
+        yield mock_boto3_client
+
+
+@patch("oracledb.connect")
+def test_connection(mock_oracledb_connect, mock_boto3_client):
+    with database.connection() as conn:
+        assert conn is not None
+
+    assert conn.closed
+
+
+@patch("oracledb.connect")
+def test_cursor(mock_oracledb_connect, mock_boto3_client):
+    with database.cursor() as cursor:
+        assert cursor is not None
+
+    assert cursor.closed
+
+
+def test_connection_params(mock_boto3_client):
+    assert database.connection_params() == {"user": "test", "password": "test", "dsn": "test_host:1521/test_sid"}
+
+
+def test_get_secret(mock_boto3_client):
+    assert database.get_secret() == {"username": "test", "password": "test"}
+
+
+def test_get_client(monkeypatch):
+    monkeypatch.setenv("region_name", "uk-west-1")
+    database.client = None
+
+    assert database.get_client() is not None

--- a/tests/unit/message_status_handler/test_message_status_recorder.py
+++ b/tests/unit/message_status_handler/test_message_status_recorder.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock, patch
+
+import message_status_recorder
+
+
+@patch("message_status_recorder.update_message_status", return_value=12)
+@patch("message_status_recorder.database.cursor")
+def test_record_message_statuses(mock_cursor, mock_update_message_status):
+    batch_id = "batch_id"
+    json_data = {
+        "data": [
+            {"message_reference": "message_reference_1"},
+            {"message_reference": "message_reference_2"},
+        ]
+    }
+    message_status_recorder.record_message_statuses(batch_id, json_data)
+
+    assert mock_update_message_status.call_count == 2
+    mock_update_message_status.assert_any_call(mock_cursor().__enter__(), batch_id, "message_reference_1")
+    mock_update_message_status.assert_any_call(mock_cursor().__enter__(), batch_id, "message_reference_2")
+
+
+@patch("message_status_recorder.database.cursor")
+def test_update_message_status(mock_cursor):
+    mock_cursor_contextmanager = mock_cursor().__enter__()
+    mock_var = Mock(getvalue=Mock(return_value=12))
+    mock_cursor_contextmanager.var.return_value = mock_var
+
+    response_code = message_status_recorder.update_message_status(mock_cursor_contextmanager, "batch_id", "message_reference_1")
+
+    assert mock_cursor_contextmanager.execute.call_count == 1
+    assert response_code == 12
+    mock_cursor_contextmanager.execute.assert_called_once_with(
+        """
+            begin
+                :out_val := pkg_notify_wrap.f_update_message_status(:in_val1, :in_val2, :in_val3);
+            end;
+        """,
+        {
+            "in_val1": "batch_id",
+            "in_val2": "message_reference_1",
+            "in_val3": "read",
+            "out_val": mock_var,
+        },
+    )


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7199

This PR will eventually join up with making a request to the Communication Management API GET statuses endpoint.

- Adds a module to save message status of `read` via an Oracle procedure. Takes a batch id and the message data from the GET statuses endpoint
- Adds a simplistic `database` module, we've not quite converged on a solution for how we connect and obtain a cursor. My 2p is we should use a context manager as it allows us to close connections and cursors when exiting the context, may need to integrate this with other PRs in flight.
- Fixes a problem with tests introduced in https://github.com/NHSDigital/bcss-notify-integration/pull/26 where test directories used the opposing function name.
- Fixes another issue which surfaced with tests, lambda function tests and pytest patch decorators do not play nicely as the patch decorator patches at test suite level, fun when you are testing two modules called `lambda_function`. Serverless ftw.