### PR TITLE
Make message_reference unique

### DIFF
--- a/batch_notification_processor/batch_processor.py
+++ b/batch_notification_processor/batch_processor.py
@@ -1,4 +1,6 @@
 import logging
+import hashlib
+import time
 import uuid
 import oracledb
 from oracle_database import OracleDatabase, DatabaseConnectionError, DatabaseFetchError
@@ -48,4 +50,5 @@ class BatchProcessor:
 
     @staticmethod
     def generate_message_reference():
-        return str(uuid.uuid4())
+        str_val = str(time.time())
+        return str(uuid.UUID(hashlib.md5(str_val.encode()).hexdigest()))

--- a/tests/unit/batch_notification_processor/test_batch_processor.py
+++ b/tests/unit/batch_notification_processor/test_batch_processor.py
@@ -2,6 +2,7 @@ from batch_processor import BatchProcessor
 from oracle_database import OracleDatabase, DatabaseFetchError
 from recipient import Recipient
 import pytest
+import re
 from unittest.mock import MagicMock, patch
 import uuid
 
@@ -103,3 +104,16 @@ class TestBatchProcessor:
             ((recipients[0],),),
             ((recipients[1],),),
         ]
+
+    def test_generate_message_reference(self, mock_oracle_database, db_config):
+        subject = BatchProcessor(batch_id, db_config)
+
+        message_reference = subject.generate_message_reference()
+
+        assert isinstance(message_reference, str)
+        assert len(message_reference) == 36
+        assert re.match(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", message_reference)
+        for _ in range(100):
+            assert message_reference != subject.generate_message_reference()
+
+


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-7781
NHS Notify needs a unique UUID4 value for `messageReference`, Oracle cannot generate this despite costing a lot. So use `time.time()` as the seed for the uuid to ensure uniqueness and set this on the message queue view.