### PR TITLE
Add Oracle container for integration tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,10 @@
+API_KEY=api-key
+APPLICATION_ID=application-id
+COMMGT_BASE_URL=http://localhost:7071
+DATABASE_USER=mpi_notify_user
+DATABASE_PASSWORD=test
+DATABASE_SID=FREEPDB1
+DATABASE_HOST=localhost
+DATABASE_PORT=1521
+REGION_NAME=uk-east-1
+SECRET_ARN=arn:partition:service:region:account-id:resource-id

--- a/.github/workflows/test-stage.yml
+++ b/.github/workflows/test-stage.yml
@@ -40,3 +40,40 @@ jobs:
       - name: "run unit testing:"
         run: |
           ./test-unit.sh
+  integration-tests:
+    name: "Integration tests"
+    needs: set-up-dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    services:
+      oracle:
+        image: gvenzl/oracle-free:latest
+        env:
+          APP_USER: mpi_notify_user
+          APP_USER_PASSWORD: test
+          ORACLE_PASSWORD: password
+        ports:
+          - 1521:1521
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+          --name oracle
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: "Migrate database"
+        run: |
+          docker cp tests/db/schema.sql oracle:/container-entrypoint-initdb.d/my-init.sql
+          docker exec oracle /bin/bash -c "sqlplus system/password@localhost:1521/FREEPDB1 @/container-entrypoint-initdb.d/my-init.sql"
+
+      - name: "Install dependencies"
+        run: |
+          pip install pipenv
+          pipenv install --dev --system
+
+      - name: "Run integration tests"
+        run: |
+          pytest tests/integration

--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ virtualenv = "*"
 requests-mock = "*"
 pytest = "*"
 pytest-cov = "*"
+dotenv = "*"
 
 [requires]
 python_version = "3.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0dae7b42bfd2a5862f8f17cd162bdc7a04b865d01c7e809bea035d71e2ff3fad"
+            "sha256": "b45b1b8c7348e45749611bd6d66f416f30e4409a13e05b6558199e580b68b3b9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -692,6 +692,13 @@
             "markers": "python_version >= '3.9'",
             "version": "==7.7.0"
         },
+        "dotenv": {
+            "hashes": [
+                "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9"
+            ],
+            "index": "pypi",
+            "version": "==0.9.9"
+        },
         "idna": {
             "hashes": [
                 "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
@@ -742,6 +749,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==6.0.0"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5",
+                "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.0"
         },
         "requests": {
             "hashes": [

--- a/batch_notification_processor/communication_management.py
+++ b/batch_notification_processor/communication_management.py
@@ -9,9 +9,9 @@ import requests
 
 class CommunicationManagement:
     def __init__(self) -> None:
-        self.base_url = os.getenv("base_url")
-        self.application_id = os.getenv("application_id")
-        self.api_key = os.getenv("api_key")
+        self.base_url = os.getenv("COMMGT_BASE_URL")
+        self.application_id = os.getenv("APPLICATION_ID")
+        self.api_key = os.getenv("API_KEY")
         self.secret = f"{self.application_id}.{self.api_key}"
 
     def send_batch_message(

--- a/batch_notification_processor/lambda_function.py
+++ b/batch_notification_processor/lambda_function.py
@@ -12,7 +12,7 @@ from scheduler import Scheduler
 
 
 def secrets_client():
-    return boto3.client("secretsmanager", region_name=os.getenv("region_name"))
+    return boto3.client("secretsmanager", region_name=os.getenv("REGION_NAME"))
 
 
 def get_secret(secret_name: str) -> dict:
@@ -31,12 +31,12 @@ def get_secret(secret_name: str) -> dict:
 
 
 def db_config():
-    db_secret = get_secret(os.getenv("secret_arn"))
+    db_secret = get_secret(os.getenv("SECRET_ARN"))
 
     return {
         "user": db_secret["username"],
         "password": db_secret["password"],
-        "dsn": f"{os.getenv('host')}:{os.getenv('port')}/{os.getenv('sid')}",
+        "dsn": f"{os.getenv('DATABASE_HOST')}:{os.getenv('DATABASE_PORT')}/{os.getenv('DATABASE_SID')}",
     }
 
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,19 @@
+services:
+  oracle:
+    image: gvenzl/oracle-free:latest
+    ports:
+      - "1521:1521"
+    environment:
+      ORACLE_PASSWORD: password
+      APP_USER: mpi_notify_user
+      APP_USER_PASSWORD: test
+    healthcheck:
+      test: ["CMD", "healthcheck.sh"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+    volumes:
+      - ./tests/db/schema.sql:/container-entrypoint-initdb.d/my-init.sql:ro
+    profiles:
+      - integration-test

--- a/tests/db/schema.sql
+++ b/tests/db/schema.sql
@@ -1,0 +1,171 @@
+ALTER SESSION SET CONTAINER=FREEPDB1;
+ALTER SESSION SET CURRENT_SCHEMA=MPI_NOTIFY_USER;
+
+GRANT ALL PRIVILEGES TO MPI_NOTIFY_USER IDENTIFIED BY "test";
+GRANT UNLIMITED TABLESPACE TO MPI_NOTIFY_USER;
+
+CREATE TABLESPACE MPI_NOTIFY_USER DATAFILE 'mpi_notify_user.dbf' SIZE 100M AUTOEXTEND ON NEXT 10M MAXSIZE UNLIMITED;
+
+COMMIT;
+
+CREATE TABLE notify_message_queue (
+  nhs_number            VARCHAR2 (10) NOT NULL,
+  event_status_id       NUMBER (38),
+  batch_id              VARCHAR2 (36),
+  message_id            VARCHAR2 (36),
+  message_definition_id NUMBER (38) NOT NULL,
+  message_status        VARCHAR2 (25) NOT NULL,
+  subject_id            NUMBER (38),
+  event_id              NUMBER (38),
+  pio_id                NUMBER (38),
+  created_datestamp     TIMESTAMP (6) DEFAULT SYSTIMESTAMP NOT NULL,
+  read_datestamp        TIMESTAMP (6),
+  bcss_error_id         NUMBER (38),
+  address_id            NUMBER (38),
+  address_version_id    NUMBER (38),
+  address_line_1        VARCHAR2 (40),
+  address_line_2        VARCHAR2 (40),
+  address_line_3        VARCHAR2 (40),
+  address_line_4        VARCHAR2 (40),
+  address_line_5        VARCHAR2 (40),
+  postcode              VARCHAR2 (12),
+  gp_practice_name      VARCHAR2 (100)
+)
+RESULT_CACHE (MODE DEFAULT)
+TABLESPACE MPI_NOTIFY_USER
+NOCOMPRESS;
+
+CREATE TABLE notify_message_definition (
+  message_definition_id         NUMBER (38) NOT NULL,
+  routing_plan_id               VARCHAR2 (36) NOT NULL,
+  event_status_id               NUMBER (38) NOT NULL,
+  message_code                  VARCHAR2 (12) NOT NULL,
+  message_name                  VARCHAR2 (100) NOT NULL,
+  parameter_id                  NUMBER (38),
+  end_date                      DATE,
+  audit_reason                  VARCHAR2 (250) NOT NULL,
+  variable_text_1               VARCHAR2 (4000),
+  prevalent_incident_status_id  NUMBER (38),
+  gp_practice_endorsement       VARCHAR2 (1),
+  subject_had_cancer_previously VARCHAR2 (1)
+)
+RESULT_CACHE (MODE DEFAULT)
+TABLESPACE MPI_NOTIFY_USER
+NOCOMPRESS;
+
+CREATE TABLE message_types (
+  message_type_id   NUMBER (38) NOT NULL,
+  message_type_name VARCHAR2 (100) NOT NULL
+)
+RESULT_CACHE (MODE DEFAULT)
+TABLESPACE MPI_NOTIFY_USER
+NOCOMPRESS;
+
+CREATE TABLE notify_message_batch (
+  batch_id              VARCHAR2 (36) NOT NULL,
+  message_definition_id	NUMBER (38) NOT NULL,
+  batch_status          VARCHAR2 (25) NOT NULL
+)
+RESULT_CACHE (MODE DEFAULT)
+TABLESPACE MPI_NOTIFY_USER
+NOCOMPRESS;
+
+CREATE TABLE ep_event_status_transition_t (
+  key_id          NUMBER (38) NOT NULL,
+  event_id        NUMBER (38) NOT NULL,
+  from_status_id  NUMBER (38) NOT NULL,
+  to_status_id    NUMBER (38) NOT NULL
+)
+RESULT_CACHE (MODE DEFAULT)
+TABLESPACE mpi_notify_user
+NOCOMPRESS;
+
+COMMIT;
+
+CREATE OR REPLACE PACKAGE MPI_NOTIFY_USER.pkg_notify_wrap AS
+  FUNCTION f_get_next_batch (pi_batch_id IN notify_message_batch.batch_id%TYPE)
+    RETURN notify_message_definition.routing_plan_id%TYPE;
+
+  FUNCTION f_update_message_status (
+    pi_batch_id         IN notify_message_queue.batch_id%TYPE,
+    pi_message_id       IN notify_message_queue.message_id%TYPE,
+    pi_message_status   IN notify_message_queue.message_status%TYPE
+  )
+    RETURN message_types.message_type_id%TYPE;
+
+END pkg_notify_wrap;
+/
+
+CREATE OR REPLACE PACKAGE BODY MPI_NOTIFY_USER.pkg_notify_wrap AS
+  FUNCTION f_get_next_batch (pi_batch_id IN notify_message_batch.batch_id%TYPE)
+    RETURN notify_message_definition.routing_plan_id%TYPE IS
+    v_routing_plan_id notify_message_definition.routing_plan_id%TYPE;
+    c_function_name  CONSTANT VARCHAR2 (35) := 'PKG_NOTIFY.f_get_next_batch';
+  BEGIN
+    SELECT  nmd.routing_plan_id
+    INTO    v_routing_plan_id
+    FROM    notify_message_definition nmd
+    WHERE   nmd.message_definition_id = 1;
+
+    UPDATE  notify_message_queue nmq
+    SET     nmq.batch_id      = pi_batch_id,
+            nmq.message_status = 'requested'
+    WHERE   nmq.message_status = 'new'
+    AND     nmq.message_definition_id = 1;
+    RETURN  v_routing_plan_id;
+  END f_get_next_batch;
+
+  FUNCTION f_update_message_status (
+    pi_batch_id         IN notify_message_queue.batch_id%TYPE,
+    pi_message_id       IN notify_message_queue.message_id%TYPE,
+    pi_message_status   IN notify_message_queue.message_status%TYPE
+  )
+    RETURN message_types.message_type_id%TYPE IS
+    v_subject_id          notify_message_queue.subject_id%TYPE;
+    v_pio_id              notify_message_queue.pio_id%TYPE;
+    v_transition_key_id   ep_event_status_transition_t.key_id%TYPE;
+    v_event_id            notify_message_queue.event_id%TYPE;
+    v_error_id            message_types.message_type_id%TYPE := 0;
+    v_read_datestamp      notify_message_queue.read_datestamp%TYPE;
+    v_message_is_complete BOOLEAN := FALSE;
+  BEGIN
+    UPDATE  notify_message_queue nmq
+    SET     nmq.message_status = pi_message_status,
+            nmq.read_datestamp = SYSTIMESTAMP
+    WHERE   nmq.batch_id = pi_batch_id
+    AND     nmq.message_id = pi_message_id;
+  END f_update_message_status;
+END pkg_notify_wrap;
+/
+
+SHOW ERRORS;
+
+COMMIT;
+
+CREATE OR REPLACE VIEW MPI_NOTIFY_USER.v_notify_message_queue
+AS
+  SELECT  nmq.nhs_number,
+          nmq.message_id,
+          nmq.batch_id,
+          nmd.routing_plan_id,
+          nmq.message_status,
+          nmd.variable_text_1,
+          nmq.address_line_1,
+          nmq.address_line_2,
+          nmq.address_line_3,
+          nmq.address_line_4,
+          nmq.address_line_5,
+          nmq.postcode
+  FROM MPI_NOTIFY_USER.notify_message_queue nmq
+      INNER JOIN MPI_NOTIFY_USER.notify_message_definition nmd
+         ON nmd.message_definition_id = nmq.message_definition_id;
+
+
+INSERT INTO MPI_NOTIFY_USER.notify_message_definition (message_definition_id, routing_plan_id, event_status_id, message_code, message_name, parameter_id, end_date, audit_reason, prevalent_incident_status_id, gp_practice_endorsement, subject_had_cancer_previously, variable_text_1) VALUES (
+1, 'c3f31ae4-1532-46df-b121-3503db6b32d6', 11197, 'S1a', 'Pre-invitation: incident subjects with no previous cancer diagnosis', 212, NULL, 'BCSS-18672', 203151, NULL, 'N', 'We offer screening every 2 years to try and find signs of bowel cancer at an early stage when there are no symptoms. This is when treatment can be more effective.');
+
+INSERT INTO MPI_NOTIFY_USER.notify_message_definition (message_definition_id, routing_plan_id, event_status_id, message_code, message_name, parameter_id, end_date, audit_reason, prevalent_incident_status_id, gp_practice_endorsement, subject_had_cancer_previously, variable_text_1) VALUES (
+2, 'c3f31ae4-1532-46df-b121-3503db6b32d6', 11197, 'S1b', 'Pre-invitation: incident subjects with previous cancer diagnosis', 212, NULL, 'BCSS-18672', 203151, NULL, 'Y', 'Routine screening may not be suitable if you are having ongoing care or treatment for a bowel condition, following a previous referral. You can contact us for advice.');
+
+
+COMMIT;

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+# The bcss-notify-integration repo contains several modules called lambda_function.py
+# This is a pattern enforced by AWS Lambda, but it makes it difficult to import the 
+# correct module in tests as import order is not guaranteed.
+# To work around this, we remove any existing modules from the sys.modules cache
+# named "lambda_function" before importing the module we want to test.
+if "lambda_function" in sys.modules:
+    del sys.modules["lambda_function"]
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../batch_notification_processor")

--- a/tests/integration/test_batch_notification_processor_updates_message_queue.py
+++ b/tests/integration/test_batch_notification_processor_updates_message_queue.py
@@ -1,0 +1,106 @@
+import boto3
+from contextlib import contextmanager
+import dotenv
+import json
+from lambda_function import lambda_handler
+import oracledb
+import os
+import pytest
+from recipient import Recipient
+import requests_mock
+from unittest.mock import Mock, patch
+
+
+dotenv.load_dotenv(".env.test")
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("TRUNCATE TABLE notify_message_queue")
+        cursor.execute("TRUNCATE TABLE notify_message_batch")
+        conn.commit()
+        cursor.close()
+
+
+def batch_id():
+    return "d3f31ae4-1532-46df-b121-3503db6b32d6"
+
+@pytest.fixture
+def recipients():
+    return [
+        Recipient(("9449304424", "51c33851-5ad6-499d-91f0-38618fb15fcd")),
+        Recipient(("9449305552", "e6c4a2d8-780e-4d28-a5e5-ee89be535e22")),
+        Recipient(("9449306621", "83452037-abe2-4b34-acf9-7ba2015cd84b")),
+        Recipient(("9449306613", "e5fa43a0-37ba-45f6-a4dd-2d9d8b6f66b2")),
+        Recipient(("9449306605", "360641b3-3258-4076-8d23-3582fcf9ba91")),
+    ]
+
+@contextmanager
+def connection():
+    user = os.getenv("DATABASE_USER")
+    password = os.getenv("DATABASE_PASSWORD")
+    dsn = f"{os.getenv('DATABASE_HOST')}:{os.getenv('DATABASE_PORT')}/{os.getenv('DATABASE_SID')}"
+    conn = oracledb.connect(user=user, password=password, dsn=dsn)
+    yield conn
+
+
+def seed_message_queue(recipients):
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            INSERT INTO notify_message_batch (batch_id, message_definition_id, batch_status)
+            VALUES (:batch_id, 1, 'new')
+        """, batch_id=batch_id())
+        for recipient in recipients:
+            cursor.execute(
+                """
+                INSERT INTO notify_message_queue (
+                    nhs_number, message_id, event_status_id, message_definition_id, message_status,
+                    subject_id, event_id, pio_id
+                ) VALUES (:nhs_number, :message_reference, 11197, 1, 'new', 1, 1, 1)
+                """,
+                nhs_number=recipient.nhs_number,
+                message_reference=recipient.message_id
+            )
+
+        conn.commit()
+        cursor.close()
+
+@patch("lambda_function.generate_batch_id", return_value=batch_id())
+def test_batch_notification_processor_updates_message_queue(mock_generate_batch_id, recipients):
+    secrets_client = Mock()
+    secret_string = json.dumps({
+        "username": os.getenv("DATABASE_USER"),
+        "password": os.getenv("DATABASE_PASSWORD")
+    })
+    secrets_client.get_secret_value.return_value = {"SecretString": secret_string}
+    boto3.client = Mock(return_value=secrets_client)
+    with patch("lambda_function.BatchProcessor.generate_message_reference", 
+               side_effect=[r.message_id for r in recipients]):
+
+        seed_message_queue(recipients)
+
+        with requests_mock.Mocker() as rm:
+            rm.post(
+                f"{os.getenv('COMMGT_BASE_URL')}/api/message/batch",
+                status_code=201,
+                json={"data": {"id": "batch_id"}},
+            )
+
+            lambda_handler({}, {})
+
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT nhs_number, message_id, message_status FROM v_notify_message_queue WHERE batch_id = :batch_id",
+            batch_id=batch_id()
+        )
+        results = cursor.fetchall()
+        cursor.close()
+
+    assert len(results) == 5
+    for idx, result in enumerate(results):
+        recipient = recipients[idx]
+        assert result == (recipient.nhs_number, recipient.message_id, "SENDING")

--- a/tests/unit/batch_notification_processor/test_communication_management.py
+++ b/tests/unit/batch_notification_processor/test_communication_management.py
@@ -2,15 +2,14 @@ from communication_management import CommunicationManagement
 from recipient import Recipient
 import pytest
 import requests_mock
-import unittest.mock
 
 
 class TestCommunicationManagement:
     @pytest.fixture
     def setup(self, monkeypatch):
-        monkeypatch.setenv("base_url", "http://example.com")
-        monkeypatch.setenv("application_id", "application_id")
-        monkeypatch.setenv("api_key", "api_key")
+        monkeypatch.setenv("COMMGT_BASE_URL", "http://example.com")
+        monkeypatch.setenv("APPLICATION_ID", "application_id")
+        monkeypatch.setenv("API_KEY", "api_key")
 
 
     def test_send_batch_message(self, setup):

--- a/tests/unit/batch_notification_processor/test_lambda_function.py
+++ b/tests/unit/batch_notification_processor/test_lambda_function.py
@@ -13,9 +13,9 @@ def test_lambda_handler(monkeypatch):
     mock_scheduler = Mock()
     lambda_function.Scheduler = mock_scheduler
     lambda_function.generate_batch_id = Mock(return_value="b3b3b3b3-b3b3-b3b3b3b3-b3b3b3b3b3b3")
-    monkeypatch.setenv("host", "host")
-    monkeypatch.setenv("port", "port")
-    monkeypatch.setenv("sid", "sid")
+    monkeypatch.setenv("DATABASE_HOST", "host")
+    monkeypatch.setenv("DATABASE_PORT", "port")
+    monkeypatch.setenv("DATABASE_SID", "sid")
     secrets_client = Mock()
     secrets_client.get_secret_value.return_value = {"SecretString": '{"username": "user", "password": "pass"}'}
     boto3.client = Mock(return_value=secrets_client)
@@ -67,8 +67,8 @@ def test_get_secret():
 def test_db_config(monkeypatch):
     monkeypatch.setenv("username", "user")
     monkeypatch.setenv("password", "pass")
-    monkeypatch.setenv("host", "host")
-    monkeypatch.setenv("port", "port")
-    monkeypatch.setenv("sid", "sid")
+    monkeypatch.setenv("DATABASE_HOST", "host")
+    monkeypatch.setenv("DATABASE_PORT", "port")
+    monkeypatch.setenv("DATABASE_SID", "sid")
     config = lambda_function.db_config()
     assert config == {"user": "user", "password": "pass", "dsn": "host:port/sid"}


### PR DESCRIPTION
## Changes in this PR:

- Adds an oracle-free container via docker compose which we can use for local development and integration/e2e tests
- Adds a mvp schema emulating parts of BCSS Oracle, we may want to add complexity as we add tests.
- Adds an integration test and includes the integration tests oracle container CI jobs, the test is very basic and a bit hardwired, more a proof we can use the container.
- Upcases all environment variable names, we may have to check this works with current terraform implementation.


## Context

We can't run CI against a full installation of BCSS on Oracle. 
We also don't have a way to develop against BCSS Oracle without connecting to the Texas VPN. 
The test instance is currently offline in any case and we need a DBA to revive and manage it.
So many reasons why we should not try to validate our work against it.
We can use a similar container with some of the tables, functions and views we interact with in our own code though.