### PR TITLE
Simplify message status handler

### DIFF
--- a/message_status_handler/comms_management.py
+++ b/message_status_handler/comms_management.py
@@ -2,36 +2,16 @@ import os
 import requests
 import logging
 
-BASE_URL = "http://example.com"
-APPLICATION_ID = os.getenv("application_id")
-API_KEY = os.getenv("api_key")
-SECRET = f"{APPLICATION_ID}.{API_KEY}"
 
-def get_statuses(
-    batch_reference: str,
-    nhs_number: str
-) -> requests.Response:
-
-    headers = {
-        "x-api-key": API_KEY,
-        "api-host": APPLICATION_ID
-    }
-
-    params = {
-        "batchReference": batch_reference,
-        "nhsNumber": nhs_number
-    }
-
-    url = f"{BASE_URL}/statuses"
-
+def get_read_messages(batch_reference: str) -> dict:
     response = requests.get(
-        url,
-        headers=headers,
-        params= params,
+        f"{os.getenv('COMMGT_BASE_URL')}/api/statuses",
+        headers={"x-api-key": os.getenv("API_KEY")},
+        params={"batchReference": batch_reference, "status": "read"},
         timeout=10
     )
 
     if response.status_code != 201:
-        logging.error("Failed to get batch message: %s ", response.json())
+        logging.error("Failed to fetch read messages: %s ", response.json())
 
-    return response
+    return response.json()

--- a/message_status_handler/lambda_function.py
+++ b/message_status_handler/lambda_function.py
@@ -1,113 +1,33 @@
+import comms_management
 import json
-import hashlib
-import hmac
 import logging
-import os
+import message_status_recorder
 from typing import Dict, Any
-import requests
-from oracle.oracle import (
-    get_connection,
-    close_connection,
-    get_cursor,
-    get_queue_table_records,
-    call_update_message_status,
-    close_cursor,
-    commit_changes,
-)
-
-
-def generate_hmac_signature(secret: str, body: str) -> str:
-    """Generate HMAC-SHA256 signature for request body."""
-    return hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
-
-
-def validate_signature(received_signature: str, secret: str, body: str) -> bool:
-    """Validate received HMAC-SHA256 signature."""
-    expected_signature = generate_hmac_signature(secret, body)
-    return hmac.compare_digest(received_signature, expected_signature)
 
 
 def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
-    """AWS Lambda function to handle NHS Notify callbacks."""
-    logging.info("Lambda function has started with event: %s", event)
-
+    logging.info("Message status handler started. Event: %s", event)
     try:
+        batch_id = event.get("batch_id")
+        messages_with_read_status = comms_management.get_read_messages(batch_id)
 
-        headers = event.get("headers", {})
-        body = event.get("body", "")
-
-        api_key = headers.get("x-api-key")
-        received_signature = headers.get("x-hmac-sha256-signature")
-
-        expected_api_key = os.getenv("NHS_NOTIFY_API_KEY")
-        application_id = os.getenv("NHS_NOTIFY_APPLICATION_ID")
-        if not api_key or api_key != expected_api_key:
-            return {
-                "statusCode": 401,
-                "body": json.dumps({"message": "Unauthorized: Invalid API Key"}),
-            }
-
-        logging.info("API key present and is matching")
-
-        secret = f"{application_id}.{expected_api_key}"
-        if not received_signature or not validate_signature(
-            received_signature, secret, body
-        ):
-            return {
-                "statusCode": 403,
-                "body": json.dumps({"message": "Forbidden: Invalid HMAC Signature"}),
-            }
-
-        logging.info("Secret is valid")
-
-        try:
-            body_data = json.loads(body)
-            logging.debug("Body data: %s", body_data)
-        except json.JSONDecodeError:
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"message": "Bad Request: Invalid JSON"}),
-            }
-
-        idempotency_key = body_data["data"][0]["meta"]["idempotencyKey"]
-        logging.debug("Idempotency key: %s", idempotency_key)
-        if not idempotency_key:
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"message": "Bad Request: Missing idempotencyKey"}),
-            }
-
-        logging.info("Idempotency key present")
-
-        if is_duplicate_request(idempotency_key):
+        if len(messages_with_read_status) == 0:
             return {
                 "statusCode": 200,
-                "body": json.dumps({"message": "Duplicate request: Already processed"}),
+                "body": json.dumps(
+                    {"message": "No messages with read status found."}
+                ),
             }
-        logging.info("Idempotency key not duplicate")
 
-        connection = get_connection()
-        logging.info("Connected to BCSS Database")
-        message_id = get_status_from_notify_api(body_data)
-        logging.info("Message ID: %s", message_id)
-        queue_dict = get_queue_table_records(connection, logging)
-        recipient_to_update = patient_to_update(connection, message_id, queue_dict)
-        logging.debug("Recipient to update: %s", recipient_to_update)
-        response_code = update_message_status(connection, recipient_to_update)
-
-        close_cursor(connection.cursor())
-        close_connection(connection.close())
+        bcss_response_codes = message_status_recorder.record_message_statuses(batch_id, messages_with_read_status)
 
         return {
             "statusCode": 200,
             "body": json.dumps(
                 {
-                    "message": "Callback processed successfully",
-                    "data": body_data,
-                    "message_reference": message_id,
-                    "bcss_response": (
-                        response_code if response_code else "No updates made"
-                    ),
+                    "message": "Message status updates successful",
+                    "data": messages_with_read_status,
+                    "bcss_response": bcss_response_codes,
                 }
             ),
         }
@@ -117,148 +37,3 @@ def lambda_handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
             "statusCode": 500,
             "body": json.dumps({"message": f"Internal Server Error: {str(e)}"}),
         }
-
-
-def is_duplicate_request(_idempotency_key: str) -> bool:
-    """Check if the request has already been processed based on the idempotency key."""
-    return False
-
-
-def get_status_from_notify_api(data: Dict[str, Any]):
-    """Process the callback data."""
-    try:
-
-        message_id = data[0]["attributes"]["messageReference"]
-
-        if not message_id:
-            raise ValueError("Missing messageReference in callback data")
-
-        return message_id
-
-    except (KeyError, ValueError) as e:
-        logging.error("Error processing callback: %s", e)
-        raise
-
-
-def patient_to_update(connection, message_id, queue_dict) -> dict:
-    cursor = get_cursor(connection)
-    var = cursor.var(int)
-    queue_dict_by_message_id = {
-        str(queue_patient["MESSAGE_ID"]): queue_patient for queue_patient in queue_dict
-    }
-    data = False
-    if message_id in queue_dict_by_message_id:
-        queue_patient = queue_dict_by_message_id[message_id]
-
-        data = {
-            "in_val1": queue_patient["BATCH_ID"],
-            "in_val2": queue_patient["MESSAGE_ID"],
-            "in_val3": "read",
-            "out_val": var,
-        }
-    close_cursor(cursor)
-    return data
-
-
-def update_message_status(connection, recipient_to_update):
-    cursor = get_cursor(connection)
-
-    logging.info("Record to update: %s", recipient_to_update)
-    response_code = call_update_message_status(cursor, recipient_to_update)
-    message_id = recipient_to_update["MESSAGE_ID"]
-
-    if response_code == 0:
-        logging.info("Message status updated successfully")
-    else:
-        logging.error("Failed to update message status for message_id: %s", message_id)
-
-    # db.commit_changes(connection)
-    close_cursor(cursor)
-    close_connection(connection)
-
-    return response_code
-
-
-def get_message_references(response, message_references):
-    try:
-        for item in response:
-            message_reference = item[0]["attributes"]["messageReference"]
-
-            if not message_reference:
-                raise ValueError("Missing Value: 'messageReference' in API data")
-
-            message_references.append(message_reference)
-
-        return message_references
-
-    except KeyError as e:
-        logging.error(
-            "Error processing API response JSON: Missing Key: %s in API data", e
-        )
-        raise
-    except ValueError as e:
-        logging.error("Error processing API response JSON: %s", e)
-        raise
-
-
-def get_statuses_from_communication_management_api(batch_id):
-    try:
-        message_references = []
-        response = requests.get(
-            f"{os.getenv('communication_management_api_url')}/api/statuses/{batch_id}",
-            timeout=30,
-        )
-        response.raise_for_status()
-        if response.status_code == 200:
-            message_references = get_message_references(
-                response.json(), message_references
-            )
-            return message_references
-
-        return []
-
-    except requests.exceptions.HTTPError as e:
-        logging.error(
-            "Failed to get statuses from Communication Management API: %s", str(e)
-        )
-        raise
-    except Exception as e:
-        logging.error(
-            "Error processing Communication Management API response: %s", str(e)
-        )
-        raise
-
-
-def get_recipients_to_update(connection, message_references):
-
-    existing_recipients = get_queue_table_records(connection, logging)
-
-    recipients_to_update = []
-
-    for message_reference in message_references:
-        for recipient in existing_recipients:
-            if message_reference == recipient["MESSAGE_ID"]:
-                recipients_to_update.append(recipient)
-
-    return recipients_to_update
-
-
-def update_message_statuses(connection, recipients_to_update):
-
-    response_codes = []
-    for recipient_to_update in recipients_to_update:
-        logging.info("Record to update: %s", recipient_to_update)
-        response_code = call_update_message_status(connection, recipient_to_update)
-        message_id = recipient_to_update["MESSAGE_ID"]
-
-        if response_code == 0:
-            response_codes.append({"message_id": message_id, "status": "updated"})
-        else:
-            logging.error(
-                "Failed to update message status for message_id: %s", message_id
-            )
-
-    commit_changes(connection)
-    close_connection(connection)
-
-    return response_codes

--- a/tests/unit/message_status_handler/test_comms_management.py
+++ b/tests/unit/message_status_handler/test_comms_management.py
@@ -1,29 +1,29 @@
-import unittest
+import comms_management
 import requests_mock
 
-from comms_management import get_statuses
 
-def test_get_statuses():
+def test_get_read_messages(monkeypatch):
+    monkeypatch.setenv("COMMGT_BASE_URL", "http://example.com")
+
     with requests_mock.Mocker() as rm:
-        rm.get(
-            "http://example.com/statuses",
+        adapter = rm.get(
+            "http://example.com/api/statuses",
             status_code=201,
-            json={'status': 'success',
-                  'response': 'message_batch_post_response',
-                  'data': [{
-                      'channel': 'nhsapp',
-                      'channelStatus': 'delivered',
-                      'supplierStatus': 'read',
-                      'message_id': '2WL3qFTEFM0qMY8xjRbt1LIKCzM',
-                      'message_reference': '1642109b-69eb-447f-8f97-ab70a74f5db4'
-            }]
-                  }
+            json={
+                'status': 'success',
+                'response': 'message_batch_post_response',
+                'data': [{
+                    'channel': 'nhsapp',
+                    'channelStatus': 'delivered',
+                    'supplierStatus': 'read',
+                    'message_id': '2WL3qFTEFM0qMY8xjRbt1LIKCzM',
+                    'message_reference': '1642109b-69eb-447f-8f97-ab70a74f5db4'
+                }]
+            }
         )
 
-        response = get_statuses('1234', '5678')
-        response_json = response.json()
+        response_json = comms_management.get_read_messages("c3b8e0c4-5f3d-4a2b-8c7f-1a2e9d6f3b5c")
 
-        assert response.status_code == 201
         assert response_json["status"] == "success"
         assert len(response_json["data"]) == 1
         assert response_json["data"][0]["channel"] == "nhsapp"
@@ -31,3 +31,47 @@ def test_get_statuses():
         assert response_json["data"][0]["supplierStatus"] == "read"
         assert response_json["data"][0]["message_id"] == "2WL3qFTEFM0qMY8xjRbt1LIKCzM"
         assert response_json["data"][0]["message_reference"] == "1642109b-69eb-447f-8f97-ab70a74f5db4"
+
+        assert adapter.called
+        assert adapter.call_count == 1
+        assert adapter.last_request.qs == {
+            "batchreference": ["c3b8e0c4-5f3d-4a2b-8c7f-1a2e9d6f3b5c"], "status": ["read"]
+        }
+
+
+def test_get_read_messages_no_data(monkeypatch):
+    monkeypatch.setenv("COMMGT_BASE_URL", "http://example.com")
+
+    with requests_mock.Mocker() as rm:
+        rm.get(
+            "http://example.com/api/statuses",
+            status_code=201,
+            json={
+                'status': 'success',
+                'data': []
+            }
+        )
+
+        response_json = comms_management.get_read_messages("c3b8e0c4-5f3d-4a2b-8c7f-1a2e9d6f3b5c")
+
+        assert response_json["status"] == "success"
+        assert response_json["data"] == []
+
+
+def test_get_read_messages_exception(monkeypatch):
+    monkeypatch.setenv("COMMGT_BASE_URL", "http://example.com")
+
+    with requests_mock.Mocker() as rm:
+        rm.get(
+            "http://example.com/api/statuses",
+            status_code=500,
+            json={
+                'status': 'error',
+                'data': []
+            }
+        )
+
+        response_json = comms_management.get_read_messages("c3b8e0c4-5f3d-4a2b-8c7f-1a2e9d6f3b5c")
+
+        assert response_json["status"] == "error"
+        assert response_json["data"] == []

--- a/tests/unit/message_status_handler/test_database.py
+++ b/tests/unit/message_status_handler/test_database.py
@@ -5,11 +5,11 @@ from unittest.mock import patch
 
 @pytest.fixture
 def mocked_env(monkeypatch):
-    monkeypatch.setenv("bcss_host", "test_host")
-    monkeypatch.setenv("port", "1521")
-    monkeypatch.setenv("sid", "test_sid")
-    monkeypatch.setenv("bcss_secret_name", "test_secret")
-    monkeypatch.setenv("region_name", "uk-west-1")
+    monkeypatch.setenv("DATABASE_HOST", "test_host")
+    monkeypatch.setenv("DATABASE_PORT", "1521")
+    monkeypatch.setenv("DATABASE_SID", "test_sid")
+    monkeypatch.setenv("SECRET_ARN", "test_secret")
+    monkeypatch.setenv("REGION_NAME", "uk-west-1")
 
 
 @pytest.fixture
@@ -38,14 +38,3 @@ def test_cursor(mock_oracledb_connect, mock_boto3_client):
 
 def test_connection_params(mock_boto3_client):
     assert database.connection_params() == {"user": "test", "password": "test", "dsn": "test_host:1521/test_sid"}
-
-
-def test_get_secret(mock_boto3_client):
-    assert database.get_secret() == {"username": "test", "password": "test"}
-
-
-def test_get_client(monkeypatch):
-    monkeypatch.setenv("region_name", "uk-west-1")
-    database.client = None
-
-    assert database.get_client() is not None

--- a/tests/unit/message_status_handler/test_lambda_function.py
+++ b/tests/unit/message_status_handler/test_lambda_function.py
@@ -1,332 +1,39 @@
-import hashlib
-import hmac
-import logging
-import pytest
-import requests
-import lambda_function as lf
-from unittest.mock import MagicMock
+import json
+import lambda_function
+from unittest.mock import patch
 
 
-@pytest.fixture
-def setup(monkeypatch):
-    monkeypatch.setenv("APPLICATION_ID", "application_id")
-    monkeypatch.setenv("NOTIFY_API_KEY", "api_key")
+def test_lambda_handler():
+    with patch("comms_management.get_read_messages") as mock_get_read_messages:
+        with patch("message_status_recorder.record_message_statuses") as mock_record_message_statuses:
+            mock_get_read_messages.return_value = [{"message_id": "123", "status": "read"}]
+            mock_record_message_statuses.return_value = {"status": "success"}
 
+            response = lambda_function.lambda_handler({"batch_id": "12345"}, None)
 
-def test_generate_hmac_signature_valid(setup):
-    """Test that an HMAC SHA-256 signature is generated correctly."""
-    body = "body"
-    signature = hmac.new(
-        "application_id.api_key".encode(), body.encode(), hashlib.sha256
-    ).hexdigest()
+            assert response["statusCode"] == 200
+            assert json.loads(response["body"]) == {
+                "message": "Message status updates successful",
+                "data": [{"message_id": "123", "status": "read"}],
+                "bcss_response": {"status": "success"},
+            }
 
-    assert lf.generate_hmac_signature("application_id.api_key", body) == signature
 
+def test_lambda_handler_no_messages():
+    with patch("comms_management.get_read_messages") as mock_get_read_messages:
+        mock_get_read_messages.return_value = []
 
-def test_validate_signature_valid(setup):
-    """Test that a valid signature passes verification."""
-    body = "body"
-    signature = hmac.new(
-        "application_id.api_key".encode(), body.encode(), hashlib.sha256
-    ).hexdigest()
+        response = lambda_function.lambda_handler({"batch_id": "12345"}, None)
 
-    assert lf.validate_signature(signature, "application_id.api_key", body)
+        assert response["statusCode"] == 200
+        assert json.loads(response["body"]) == {"message": "No messages with read status found."}
 
 
-def test_validate_signature_invalid(setup):
-    """Test that an invalid signature does not pass verification."""
-    body = "body"
-    signature = hmac.new(
-        "application_id.api_key".encode(), body.encode(), hashlib.sha256
-    ).hexdigest()
+def test_lambda_handler_exception():
+    with patch("comms_management.get_read_messages") as mock_get_read_messages:
+        mock_get_read_messages.side_effect = Exception("Test exception")
 
-    assert not lf.validate_signature(signature, "test", body)
+        response = lambda_function.lambda_handler({"batch_id": "12345"}, None)
 
-
-def test_lambda_handler(setup):
-    """Test that the Lambda handler returns the correct response."""
-    pass
-
-
-def test_get_status_from_notify_api(example_body_data, example_message_reference):
-    """Test that a callback is processed correctly."""
-    response = lf.get_status_from_notify_api(example_body_data)
-
-    assert response == example_message_reference
-
-
-def test_get_status_from_notify_api_invalid_missing_message_reference_value(
-    example_body_data,
-):
-    """Test that missing callback_id is handled correctly"""
-    with pytest.raises(ValueError):
-        example_body_data[0]["attributes"]["messageReference"] = ""
-        lf.get_status_from_notify_api(example_body_data)
-
-
-def test_get_status_from_notify_api_invalid_missing_attribute_index(example_body_data):
-    """Test that missing messageReference attribute is handled correctly"""
-    with pytest.raises(KeyError):
-        del example_body_data[0]["attributes"]["messageReference"]
-        lf.get_status_from_notify_api(example_body_data)
-
-
-def test_get_message_references_valid(
-    example_comms_management_response, example_message_references
-):
-    message_references = lf.get_message_references(
-        example_comms_management_response, []
-    )
-    assert message_references == example_message_references
-
-
-def test_get_message_references_invalid_missing_message_reference_value(
-    example_comms_management_response, caplog
-):
-    with pytest.raises(ValueError):
-        example_comms_management_response[0][0]["attributes"]["messageReference"] = ""
-        example_comms_management_response[1][0]["attributes"]["messageReference"] = ""
-        lf.get_message_references(example_comms_management_response, [])
-    assert caplog.records[0].levelname == "ERROR"
-    assert (
-        caplog.records[0].message
-        == "Error processing API response JSON: Missing Value: 'messageReference' in API data"
-    )
-
-
-def test_get_message_references_invalid_missing_message_reference_key(
-    example_comms_management_response, caplog
-):
-    with pytest.raises(KeyError):
-        caplog.set_level(logging.ERROR)
-        del example_comms_management_response[0][0]["attributes"]["messageReference"]
-        del example_comms_management_response[1][0]["attributes"]["messageReference"]
-        lf.get_message_references(example_comms_management_response, [])
-    assert caplog.records[0].levelname == "ERROR"
-    assert (
-        caplog.records[0].message
-        == "Error processing API response JSON: Missing Key: 'messageReference' in API data"
-    )
-
-
-def test_get_statuses_from_communication_management_api_valid(
-    mock_requests_get,
-    example_batch_id,
-    example_comms_management_response,
-    example_message_references,
-):
-    mock_comms_management_response = MagicMock()
-    mock_comms_management_response.status_code = 200
-    mock_comms_management_response.json.return_value = example_comms_management_response
-    mock_requests_get.return_value = mock_comms_management_response
-
-    mock_get_message_references = MagicMock(return_value=example_message_references)
-    lf.get_message_references = mock_get_message_references
-
-    response = lf.get_statuses_from_communication_management_api(example_batch_id)
-    mock_requests_get.assert_called_once_with(
-        f"{lf.os.getenv('communication_management_api_url')}/api/statuses/{example_batch_id}",
-        timeout=30,
-    )
-    assert response == example_message_references
-
-
-def test_get_statuses_from_communication_management_api_invalid_non_200_response(
-    mock_requests_get, example_comms_management_response, example_batch_id, caplog
-):
-    with pytest.raises(requests.exceptions.HTTPError) as e:
-        caplog.set_level(logging.ERROR)
-        mock_comms_management_response = MagicMock()
-        mock_comms_management_response.status_code = 500
-        mock_comms_management_response.json.return_value = (
-            example_comms_management_response
-        )
-        mock_comms_management_response.raise_for_status.side_effect = (
-            requests.exceptions.HTTPError("500 Server Error")
-        )
-        mock_requests_get.return_value = mock_comms_management_response
-
-        lf.get_statuses_from_communication_management_api(example_batch_id)
-        mock_requests_get.assert_called_once_with(
-            f"{lf.os.getenv('communication_management_api_url')}/api/statuses/{example_batch_id}",
-            timeout=30,
-        )
-    assert str(e.value) == "500 Server Error"
-    assert caplog.records[0].levelname == "ERROR"
-    assert (
-        caplog.records[0].message
-        == "Failed to get statuses from Communication Management API: 500 Server Error"
-    )
-
-
-def test_get_recipients_to_update(
-    mock_connection,
-    example_queue_table_data,
-    example_message_references,
-    caplog,
-):
-    caplog.set_level(logging.INFO)
-
-    recipients_to_update = lf.get_recipients_to_update(
-        mock_connection, example_message_references
-    )
-
-    assert len(recipients_to_update) == 2
-    assert recipients_to_update[0] == example_queue_table_data[0]
-    assert recipients_to_update[1] == example_queue_table_data[1]
-    assert example_queue_table_data[2] not in recipients_to_update
-
-
-def test_get_recipients_to_update_no_matches(
-    mock_connection,
-    mock_cursor,
-    example_message_references,
-    caplog,
-):
-    caplog.set_level(logging.INFO)
-    mock_cursor.fetchall.return_value = [
-        ("123456789", "false_message_id", "ABC"),
-        ("987654321", "false_message_id", "ABC"),
-        ("123987456", "example_message_id", "ABC"),
-    ]
-    mock_cursor.description = [
-        ("NHS_NUMBER",),
-        ("MESSAGE_ID",),
-        ("BATCH_ID",),
-    ]
-
-    recipients_to_update = lf.get_recipients_to_update(
-        mock_connection, example_message_references
-    )
-
-    assert len(recipients_to_update) == 0
-
-
-def test_patient_to_update_valid_match(
-    example_patient_to_update_dict, mock_connection, mock_cursor
-):
-    """Test that a valid patient is returned."""
-    message_id, queue_dict = example_patient_to_update_dict
-    data = lf.patient_to_update(mock_connection, message_id, queue_dict)
-
-    mock_var = mock_cursor.var(int)
-    mock_var.getvalue.return_value = 0
-
-    assert data["in_val1"] == "456"
-    assert data["in_val2"] == "123"
-    assert data["in_val3"] == "read"
-    assert data["out_val"] == mock_var
-
-
-def test_patient_to_update_valid_no_match(
-    example_patient_to_update_dict, mock_connection
-):
-    """Test that False is returned if no match is found."""
-    message_id, queue_dict = example_patient_to_update_dict
-    message_id = "XYZ"
-    data = lf.patient_to_update(mock_connection, message_id, queue_dict)
-
-    assert not data
-
-
-def test_update_message_status_valid(
-    mock_connection, example_recipient_to_update, caplog
-):
-    caplog.set_level(logging.INFO)
-
-    response_code = lf.update_message_status(
-        mock_connection, example_recipient_to_update
-    )
-
-    assert caplog.records[0].levelname == "INFO"
-    assert (
-        caplog.records[0].message == f"Record to update: {example_recipient_to_update}"
-    )
-
-    assert response_code == 0
-    assert caplog.records[1].levelname == "INFO"
-    assert caplog.records[1].message == "Message status updated successfully"
-
-
-def test_update_message_status_invalid(
-    mock_connection, mock_var, example_recipient_to_update, caplog
-):
-    caplog.set_level(logging.INFO)
-
-    example_recipient_to_update["MESSAGE_ID"] = "false_message_id"
-    mock_var.getvalue.return_value = 1
-
-    response_code = lf.update_message_status(
-        mock_connection, example_recipient_to_update
-    )
-
-    assert caplog.records[0].levelname == "INFO"
-    assert (
-        caplog.records[0].message == f"Record to update: {example_recipient_to_update}"
-    )
-
-    assert response_code == 1
-    assert caplog.records[1].levelname == "ERROR"
-    assert (
-        caplog.records[1].message
-        == f'Failed to update message status for message_id: {example_recipient_to_update["MESSAGE_ID"]}'
-    )
-
-
-def test_update_message_statuses_valid(
-    mock_connection,
-    example_recipients_to_update,
-    caplog,
-):
-    caplog.set_level(logging.INFO)
-
-    response_codes = lf.update_message_statuses(
-        mock_connection, example_recipients_to_update
-    )
-
-    assert caplog.records[0].levelname == "INFO"
-    assert (
-        caplog.records[0].message
-        == f"Record to update: {example_recipients_to_update[0]}"
-    )
-    assert (
-        caplog.records[1].message
-        == f"Record to update: {example_recipients_to_update[1]}"
-    )
-
-    assert response_codes == [
-        {
-            "message_id": example_recipients_to_update[0]["MESSAGE_ID"],
-            "status": "updated",
-        },
-        {
-            "message_id": example_recipients_to_update[1]["MESSAGE_ID"],
-            "status": "updated",
-        },
-    ]
-
-
-def test_update_message_statuses_invalid(
-    mock_connection,
-    mock_cursor,
-    example_recipients_to_update,
-    caplog,
-):
-    caplog.set_level(logging.ERROR)
-    mock_cursor.var.return_value.getvalue.return_value = 1
-
-    response_codes = lf.update_message_statuses(
-        mock_connection, example_recipients_to_update
-    )
-
-    assert caplog.records[0].levelname == "ERROR"
-    assert (
-        caplog.records[0].message
-        == f"Failed to update message status for message_id: {example_recipients_to_update[0]['MESSAGE_ID']}"
-    )
-    assert (
-        caplog.records[1].message
-        == f"Failed to update message status for message_id: {example_recipients_to_update[1]['MESSAGE_ID']}"
-    )
-
-    assert response_codes == []
+        assert response["statusCode"] == 500
+        assert json.loads(response["body"]) == {"message": "Internal Server Error: Test exception"}


### PR DESCRIPTION
## Context

The message status handler lambda will be scheduled to execute by the batch processor lambda in order to check on the status of message sent.
We only care about messages with a `read` status.

## Changes in this PR

- Reduce complexity of database connection and cursor retrieval
- Amend the Communications Management API client module to retrieve only read message data from the GET statuses endpoint
- Update the message queue view with results from the CM API