### PR TITLE
Add github action secret scanning using guidance from engineering framework

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,20 @@
+name: "Secret scanning stage"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  Scan-secrets:
+  name: "Scan secrets"
+  description: "Scan secrets"
+  runs:
+    using: "composite"
+    steps:
+      - name: "Scan secrets"
+        shell: bash
+        run: |
+          # Please do not change this `check=whole-history` setting, as new patterns may be added or history may be rewritten.
+          check=whole-history ./scripts/githooks/scan-secrets.sh


### PR DESCRIPTION
Using guidance from the [engineering framework](https://github.com/NHSDigital/repository-template/blob/0dda5c7793bb1032de17f243845f4ff03139cf51/docs/user-guides/Scan_secrets.md)
Add secret scanning to github actions