### PR TITLE
Fix renamed terraform values

### DIFF
--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -3,6 +3,7 @@ terraform {
     bucket         = "bcss-terraform-nonprod-iac"
     key            = "bcss/infrastructure/communication-management/terraform.tfstate"
     region         = "eu-west-2"
-    dynamodb_table = "bcss-communication-management-terraform-lock-dev"
+    dynamodb_table = "bcss-comms-manager-terraform-lock-dev"
   }
 }
+

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -3,6 +3,7 @@ terraform {
     bucket         = "bcss-terraform-nonprod-iac"
     key            = "bcss/infrastructure/communication-management/terraform.tfstate"
     region         = "eu-west-2"
-    dynamodb_table = "bcss-communication-management-terraform-lock-prod"
+    dynamodb_table = "bcss-comms-manager-terraform-lock-prod"
   }
 }
+

--- a/terraform/modules/batch_notification_processor/main.tf
+++ b/terraform/modules/batch_notification_processor/main.tf
@@ -1,14 +1,31 @@
-data "archive_file" "lambda_zip" {
-  type        = "zip"
-  output_path = "${path.module}/lambda_function.zip"
-  source_dir  = "${path.module}/../../../batch_notification_processor/"
+resource "null_resource" "zipfile" {
+  provisioner "local-exec" {
+    command     = <<EOT
+      mkdir build
+      cp ../../../batch_notification_processor/*.py build/
+      cp -r $(pipenv --venv)/lib/python3.11/site-packages/* build/
+      cd build
+      rm -rf __pycache__
+      rm -rf _pytest
+      chmod -R 644 $(find . -type f)
+      chmod -R 755 $(find . -type d)
+      zip -r ../lambda_function.zip * -x *.zip
+      cd ..
+      rm -rf build
+    EOT
+    working_dir = path.module
+  }
+  triggers = {
+    always_run = "${timestamp()}"
+  }
 }
 resource "aws_lambda_function" "batch_notification_processor" {
+  depends_on       = [null_resource.zipfile]
   function_name    = "${var.team}-${var.project}-batch-notification-processor-${var.environment}"
   handler          = "lambda_function.lambda_handler" # File.function
   runtime          = "python3.12"
-  filename         = data.archive_file.lambda_zip.output_path
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  filename         = "${path.module}/lambda_function.zip"
+  source_code_hash = filebase64sha256("${path.module}/lambda_function.zip")
   role             = var.batch_notification_processor_lambda_role_arn
 
   timeout     = 300

--- a/terraform/modules/message_status_handler/main.tf
+++ b/terraform/modules/message_status_handler/main.tf
@@ -1,14 +1,30 @@
-data "archive_file" "lambda_zip" {
-  type        = "zip"
-  output_path = "${path.module}/lambda_function.zip"
-  source_dir  = "${path.module}/../../../message_status_handler/"
+resource "null_resource" "zipfile" {
+  provisioner "local-exec" {
+    command     = <<EOT
+      mkdir build
+      cp ../../../message_status_handler/*.py build/
+      cp -r $(pipenv --venv)/lib/python3.11/site-packages/* build/
+      cd build
+      rm -rf __pycache__
+      rm -rf _pytest
+      chmod -R 644 $(find . -type f)
+      chmod -R 755 $(find . -type d)
+      zip -r ../lambda_function.zip * -x *.zip
+      cd ..
+      rm -rf build
+    EOT
+    working_dir = path.module
+  }
+  triggers = {
+    always_run = "${timestamp()}"
+  }
 }
 resource "aws_lambda_function" "message_status_handler" {
   function_name    = "${var.team}-${var.project}-message-status-handler-${var.environment}"
   handler          = "scheduled_lambda_function.lambda_handler"
   runtime          = "python3.12"
-  filename         = data.archive_file.lambda_zip.output_path
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+  filename         = "${path.module}/lambda_function.zip"
+  source_code_hash = filebase64sha256("${path.module}/lambda_function.zip")
   role             = var.message_status_handler_lambda_role_arn
 
   timeout     = 300

--- a/terraform/modules/network/main.tf
+++ b/terraform/modules/network/main.tf
@@ -10,5 +10,6 @@ data "aws_subnets" "private" {
 }
 
 data "aws_security_group" "lambda" {
-  name = "bcss-communication-management-dev-sec-grp"
+  name = "bcss-oracle-bcss-dev-sec-grp"
 }
+


### PR DESCRIPTION
Fixes a few infra values renamed recently which are easier to preserve than to recreate. These don't affect the overall resource naming which is now consistent with the lambda names.
Also adds an inline lambda zip creation step via `null_resource` script execution. We might want to revisit this but it allow `tf apply` to run. 