### PR TITLE
Fix paths to images in AWS docs

### DIFF
--- a/docs/access-aws-lambdas.md
+++ b/docs/access-aws-lambdas.md
@@ -14,21 +14,21 @@ To access AWS Lambda functions, follow the steps below:
 
    *If you do not see these accounts listed, please contact the Texas Platform team for access.*
 
-   ![AWS Account List](docs/images/aws-accounts.png)
+   ![AWS Account List](images/aws-accounts.png)
 
 3. When working in development, you should use the **NHS Digital DDC Exeter Texas NonProd K8s** account and log in as the **bcss-rw-user**.
 
 4. Once your AWS Console has loaded, **change the region to `eu-west-2` (London)** using the region selector in the top-right corner of the Console.
 
-   ![Changing the region](docs/images/region-change.png)
+   ![Changing the region](images/region-change.png)
 
 5. Once your AWS Console has loaded, use the search bar in the upper-left corner and search for **Lambda**.
 
-   ![Searching for Lambda](docs/images/lambda-search.png)
+   ![Searching for Lambda](images/lambda-search.png)
 
 6. On the main Lambda service page, select **Functions** from the sidebar.
 
-   ![Lambda Functions List](docs/images/lambda-functions-list.png)
+   ![Lambda Functions List](images/lambda-functions-list.png)
 
 7. You should now see a page listing all available Lambda functions.  
    **Be careful not to modify any functions unless you are certain they are managed by this team,** as some functions are managed by other teams.


### PR DESCRIPTION
We've moved the AWS lambda documentation into `docs/` so amend the paths to images.