### PR TITLE
Add secretsmanager aws policies to lambda roles

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -8,6 +8,7 @@ module "batch_notification_processor" {
   project        = var.project
   environment    = var.environment
   secrets        = jsondecode(data.aws_secretsmanager_secret_version.lambda_secrets.secret_string)
+  secrets_arn    = var.secrets_arn
   region         = var.region
   tags           = var.tags
   subnet_ids     = module.network.private_subnet_ids
@@ -22,6 +23,7 @@ module "message_status_handler" {
   project        = var.project
   environment    = var.environment
   secrets        = jsondecode(data.aws_secretsmanager_secret_version.lambda_secrets.secret_string)
+  secrets_arn    = var.secrets_arn
   region         = var.region
   tags           = var.tags
   sqs_queue_arn  = module.sqs.sqs_queue_arn
@@ -62,6 +64,8 @@ module "iam" {
   team                       = var.team
   project                    = var.project
   environment                = var.environment
+  kms_arn                    = var.kms_arn
+  secrets_arn                = var.secrets_arn
   sqs_queue_arn              = module.sqs.sqs_queue_arn
   notification_s3_bucket_arn = module.s3.bucket_arn
   tags                       = var.tags

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -3,6 +3,7 @@ team = "bcss"
 project = "comms"
 
 environment = "dev"
+kms_arn     = "arn:aws:kms:eu-west-2:730319765130:key/25da03db-7a99-4a15-bc38-2bf757f27fca"
 secrets_arn = "arn:aws:secretsmanager:eu-west-2:730319765130:secret:bcss-nonprod-notify-lambda-secrets-A8O202"
 region      = "eu-west-2"
 

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -18,6 +18,11 @@ variable "region" {
   default = "eu-west-2"
 }
 
+variable "kms_arn" {
+  type    = string
+  default = "arn:aws:kms:eu-west-2:123456789012:key/fe1a2b3c-4d5e-6f7g-8h9i-j0k1l2m3n4o5"
+}
+
 variable "secrets_arn" {
   type    = string
   default = "arn:aws:secretsmanager:eu-west-2:123456789012:secret:bcss-nonprod-secrets-123456"

--- a/terraform/modules/batch_notification_processor/main.tf
+++ b/terraform/modules/batch_notification_processor/main.tf
@@ -34,6 +34,8 @@ resource "aws_lambda_function" "batch_notification_processor" {
     security_group_ids = [var.security_group]
   }
 
+  layers = [var.parameters_and_secrets_lambda_extension_arn]
+
   environment {
     variables = {
       COMMGT_BASE_URL = local.secrets["commgt_base_url"]
@@ -41,6 +43,9 @@ resource "aws_lambda_function" "batch_notification_processor" {
       ENVIRONMENT     = var.environment
       OAUTH_TOKEN_URL = local.secrets["oauth_token_url"]
       REGION_NAME     = var.region
+      SECRET_ARN      = var.secrets_arn
+
+      PARAMETERS_SECRETS_EXTENSION_CACHE_ENABLED = "true"
     }
   }
 

--- a/terraform/modules/batch_notification_processor/variables.tf
+++ b/terraform/modules/batch_notification_processor/variables.tf
@@ -19,9 +19,20 @@ variable "secrets" {
   description = "Lambda secretsmanager secrets"
 }
 
+variable "secrets_arn" {
+  type        = string
+  description = "ARN for the AWS Secrets Manager secret containing the Lambda secrets"
+}
+
 variable "batch_notification_processor_lambda_role_arn" {
   type        = string
   description = "ARN for the batch processor lambda role"
+}
+
+variable "parameters_and_secrets_lambda_extension_arn" {
+  type        = string
+  description = "ARN for the parameters and secrets lambda extension"
+  default     = "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12"
 }
 
 variable "subnet_ids" {

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -27,6 +27,39 @@ resource "aws_iam_role_policy_attachment" "message_status_handler_lambda_role_vp
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
+data "aws_iam_policy_document" "lambda_secretsmanager_policy_document" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      var.secrets_arn
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "lambda_kms_policy_document" {
+  statement {
+    actions = [
+      "kms:Decrypt",
+    ]
+    resources = [
+      var.kms_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "message_status_handler_kms_policy" {
+  name   = "${var.team}-${var.project}-message-status-handler-kms-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_kms_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "message_status_handler_lambda_kms_access" {
+  role       = aws_iam_role.message_status_handler_lambda_role.name
+  policy_arn = aws_iam_policy.message_status_handler_kms_policy.arn
+}
+
 data "aws_iam_policy_document" "message_status_handler_sqs_policy_document" {
   statement {
     actions = [
@@ -101,6 +134,28 @@ resource "aws_iam_role_policy_attachment" "batch_notification_processor_lambda_r
 resource "aws_iam_role_policy_attachment" "batch_notification_processor_lambda_role_vpc_access_policy_attachment" {
   role       = aws_iam_role.batch_notification_processor_lambda_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_iam_policy" "batch_notification_processor_secretsmanager_policy" {
+  name   = "${var.team}-${var.project}-batch-notification-processor-secretsmanager-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_secretsmanager_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "batch_notification_processor_lambda_secretsmanager_access" {
+  role       = aws_iam_role.batch_notification_processor_lambda_role.name
+  policy_arn = aws_iam_policy.batch_notification_processor_secretsmanager_policy.arn
+}
+
+resource "aws_iam_policy" "batch_notification_processor_kms_policy" {
+  name   = "${var.team}-${var.project}-batch-notification-processor-kms-policy-${var.environment}"
+  policy = data.aws_iam_policy_document.lambda_kms_policy_document.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "batch_notification_processor_lambda_kms_access" {
+  role       = aws_iam_role.batch_notification_processor_lambda_role.name
+  policy_arn = aws_iam_policy.batch_notification_processor_kms_policy.arn
 }
 
 data "aws_iam_policy_document" "batch_notification_processor_s3_policy_document" {

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -10,6 +10,16 @@ variable "environment" {
   type = string
 }
 
+variable "kms_arn" {
+  type        = string
+  description = "ARN for the AWS KMS key used to encrypt the Lambda secrets"
+}
+
+variable "secrets_arn" {
+  type        = string
+  description = "ARN for the AWS Secrets Manager secret containing the Lambda secrets"
+}
+
 variable "sqs_queue_arn" {
   type        = string
   description = "ARN for the BCSS Communication Management SQS Queue"

--- a/terraform/modules/message_status_handler/main.tf
+++ b/terraform/modules/message_status_handler/main.tf
@@ -34,12 +34,17 @@ resource "aws_lambda_function" "message_status_handler" {
     security_group_ids = [var.security_group]
   }
 
+  layers = [var.parameters_and_secrets_lambda_extension_arn]
+
   environment {
     variables = {
       COMMGT_BASE_URL = local.secrets["commgt_base_url"]
       DATABASE_PORT   = local.secrets["database_port"]
       ENVIRONMENT     = var.environment
       REGION_NAME     = var.region
+      SECRET_ARN      = var.secrets_arn
+
+      PARAMETERS_SECRETS_EXTENSION_CACHE_ENABLED = "true"
     }
   }
 

--- a/terraform/modules/message_status_handler/variables.tf
+++ b/terraform/modules/message_status_handler/variables.tf
@@ -19,9 +19,20 @@ variable "secrets" {
   description = "Lambda secretsmanager secrets"
 }
 
+variable "secrets_arn" {
+  type        = string
+  description = "ARN for the AWS Secrets Manager secret containing the Lambda secrets"
+}
+
 variable "message_status_handler_lambda_role_arn" {
   type        = string
   description = "ARN for the batch processor lambda role"
+}
+
+variable "parameters_and_secrets_lambda_extension_arn" {
+  type        = string
+  description = "ARN for the parameters and secrets lambda extension"
+  default     = "arn:aws:lambda:eu-west-2:133256977650:layer:AWS-Parameters-and-Secrets-Lambda-Extension:12"
 }
 
 variable "tags" {


### PR DESCRIPTION
Adds a couple of missing policies to the lambda roles which allow us to read secrets from secretsmanager via the restful endpoint extension as recommended here https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_lambda.html

This prevents secrets being unintentionally exposed in the AWS Console and follows 12 factor principles.