### PR TITLE
Remove extraneous secrets lookup code

### DIFF
--- a/batch_notification_processor/lambda_function.py
+++ b/batch_notification_processor/lambda_function.py
@@ -10,8 +10,6 @@ import os
 
 TWELVE_HOURS_IN_MINUTES = 720
 
-environment.seed()
-
 
 def generate_batch_id():
     return str(uuid.uuid4())
@@ -26,6 +24,8 @@ def lambda_handler(event: dict, _context: object) -> dict:
         context: AWS Lambda context
     """
     logging.info("Lambda function has started.")
+
+    environment.seed()
 
     # Generate unique batch ID
     batch_id = event.get("batch_id")

--- a/batch_notification_processor/oracle_database.py
+++ b/batch_notification_processor/oracle_database.py
@@ -1,11 +1,8 @@
-import boto3
 from contextlib import contextmanager
-import json
 import logging
 from typing import Optional
 import oracledb
 import os
-
 
 
 from recipient import Recipient
@@ -117,13 +114,6 @@ class OracleDatabase:
     def connection_params():
         username = os.getenv("DATABASE_USER")
         password = os.getenv("DATABASE_PASSWORD")
-
-        if not username or not password:
-            client = boto3.client("secretsmanager", region_name=os.getenv("REGION_NAME"))
-            response = client.get_secret_value(SecretId=os.getenv("SECRET_ARN"))
-            db_secrets = json.loads(response["SecretString"])
-            username = db_secrets["username"]
-            password = db_secrets["password"]
 
         return {
             "user": username,

--- a/message_status_handler/database.py
+++ b/message_status_handler/database.py
@@ -1,6 +1,4 @@
 from contextlib import contextmanager
-import boto3
-import json
 import logging
 import oracledb
 import os
@@ -39,22 +37,8 @@ def cursor():
 
 
 def connection_params() -> dict:
-    username = os.getenv("DATABASE_USER")
-    password = os.getenv("DATABASE_PASSWORD")
-
-    if not username or not password:
-        client = boto3.client(
-            service_name="secretsmanager",
-            region_name=os.getenv("REGION_NAME"),
-        )
-        secret = json.loads(
-            client.get_secret_value(SecretId=os.getenv("SECRET_ARN"))["SecretString"]
-        )
-        username = secret["username"]
-        password = secret["password"]
-
-    db_user: str = username
-    db_password: str = password
+    db_user = os.getenv("DATABASE_USER")
+    db_password = os.getenv("DATABASE_PASSWORD")
     host: str = os.environ["DATABASE_HOST"]
     port: str = os.getenv("DATABASE_PORT", "1521")
     sid: str = os.environ["DATABASE_SID"]

--- a/tests/end_to_end/runner/conftest.py
+++ b/tests/end_to_end/runner/conftest.py
@@ -1,7 +1,5 @@
-import boto3
 from contextlib import contextmanager
 import dotenv
-import json
 import pytest
 import oracledb
 import os
@@ -43,14 +41,6 @@ class Helpers:
 
     @staticmethod
     def seed_message_queue(batch_id, recipient_data):
-        secrets_client = Mock()
-        secret_string = json.dumps({
-            "username": os.getenv("DATABASE_USER"),
-            "password": os.getenv("DATABASE_PASSWORD")
-        })
-        secrets_client.get_secret_value.return_value = {"SecretString": secret_string}
-        boto3.client = Mock(return_value=secrets_client)
-
         with Helpers.cursor() as cur:
             cur.execute("""
                 INSERT INTO notify_message_batch (batch_id, message_definition_id, batch_status)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,3 @@
-import boto3
 from contextlib import contextmanager
 import dotenv
 import json
@@ -50,16 +49,6 @@ class Helpers:
 
     @staticmethod
     def seed_message_queue(batch_id, recipient_data):
-        secrets_client = Mock()
-        secret_string = json.dumps(
-            {
-                "username": os.getenv("DATABASE_USER"),
-                "password": os.getenv("DATABASE_PASSWORD"),
-            }
-        )
-        secrets_client.get_secret_value.return_value = {"SecretString": secret_string}
-        boto3.client = Mock(return_value=secrets_client)
-
         with Helpers.cursor() as cur:
             cur.execute(
                 """

--- a/tests/integration/test_batch_notification_processor_updates_message_queue.py
+++ b/tests/integration/test_batch_notification_processor_updates_message_queue.py
@@ -1,4 +1,5 @@
 from batch_processor import BatchProcessor
+import boto3
 import dotenv
 import os
 import pytest
@@ -10,9 +11,13 @@ dotenv.load_dotenv(".env.test")
 
 import lambda_function
 
+
 def test_batch_notification_processor_updates_message_queue(
     batch_id, recipient_data, helpers
 ):
+    mock_boto3_client = Mock()
+    boto3.client = mock_boto3_client
+    mock_boto3_client.create_schedule = Mock()
     lambda_function.generate_batch_id = Mock(return_value=batch_id)
     message_references = [r[1] for r in recipient_data]
     helpers.seed_message_queue(batch_id, recipient_data)

--- a/tests/unit/batch_notification_processor/test_oracle_database.py
+++ b/tests/unit/batch_notification_processor/test_oracle_database.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import patch, Mock
 
-import boto3
 import pytest
 import oracledb
 import uuid
@@ -12,12 +11,11 @@ from recipient import Recipient
 
 @pytest.fixture
 def mock_db_credentials(monkeypatch):
+    monkeypatch.setenv("DATABASE_USER", "user")
+    monkeypatch.setenv("DATABASE_PASSWORD", "password")
     monkeypatch.setenv("DATABASE_HOST", "host")
     monkeypatch.setenv("DATABASE_PORT", "port")
     monkeypatch.setenv("DATABASE_SID", "sid")
-    secrets_client = Mock()
-    secrets_client.get_secret_value.return_value = {"SecretString": '{"username": "user", "password": "pass"}'}
-    boto3.client = Mock(return_value=secrets_client)
 
 
 @patch("oracle_database.oracledb", autospec=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -36,15 +36,6 @@ def mock_var():
 
 
 @pytest.fixture
-def mock_boto3_client():
-    mock_client = MagicMock()
-    mock_client.get_secret_value.return_value = {
-        "SecretString": '{\n  "username":"test_username",\n  "password":"test_password"\n}\n',
-    }
-    return mock_client
-
-
-@pytest.fixture
 def mock_generate_batch_id():
     mock_generate_batch_id = MagicMock()
     mock_generate_batch_id.return_value = "b3b3b3b3-b3b3-b3b3b3b3-b3b3b3b3b3b3"

--- a/tests/unit/message_status_handler/test_database.py
+++ b/tests/unit/message_status_handler/test_database.py
@@ -3,8 +3,10 @@ import pytest
 from unittest.mock import patch
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mocked_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_USER", "test")
+    monkeypatch.setenv("DATABASE_PASSWORD", "test")
     monkeypatch.setenv("DATABASE_HOST", "test_host")
     monkeypatch.setenv("DATABASE_PORT", "1521")
     monkeypatch.setenv("DATABASE_SID", "test_sid")
@@ -12,16 +14,8 @@ def mocked_env(monkeypatch):
     monkeypatch.setenv("REGION_NAME", "uk-west-1")
 
 
-@pytest.fixture
-def mock_boto3_client(mocked_env):
-    with patch("boto3.client") as mock_boto3_client:
-        mock_boto3_client.return_value.get_secret_value.return_value={"SecretString": '{"username": "test", "password": "test"}'}
-
-        yield mock_boto3_client
-
-
 @patch("oracledb.connect")
-def test_connection(mock_oracledb_connect, mock_boto3_client):
+def test_connection(mock_oracledb_connect):
     with database.connection() as conn:
         assert conn is not None
 
@@ -29,12 +23,12 @@ def test_connection(mock_oracledb_connect, mock_boto3_client):
 
 
 @patch("oracledb.connect")
-def test_cursor(mock_oracledb_connect, mock_boto3_client):
+def test_cursor(mock_oracledb_connect):
     with database.cursor() as cursor:
         assert cursor is not None
 
     assert cursor.closed
 
 
-def test_connection_params(mock_boto3_client):
+def test_connection_params():
     assert database.connection_params() == {"user": "test", "password": "test", "dsn": "test_host:1521/test_sid"}


### PR DESCRIPTION
## Context

We were retrieving some secrets (mostly database connection params) via the Python `boto3` client, but have since moved to populating the environment with secrets [as recommended for AWS lambdas](https://docs.aws.amazon.com/secretsmanager/latest/userguide/retrieving-secrets_lambda.html). We no longer need the client lookup code or test support for boto3 other than for scheduling. 

## Changes

- Remove boto3 client code for secretsmanager
- Seed the environment in the first lambda handler function invocation