### PR TITLE
Add lambda and lambda role arns for message status handler

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -14,6 +14,8 @@ module "batch_notification_processor" {
   security_group = module.network.security_group
 
   batch_notification_processor_lambda_role_arn = module.iam.batch_notification_processor_lambda_role_arn
+  message_status_handler_lambda_arn            = module.message_status_handler.message_status_handler_arn
+  message_status_handler_lambda_role_arn       = module.iam.message_status_handler_lambda_role_arn
 }
 
 module "message_status_handler" {

--- a/terraform/modules/batch_notification_processor/main.tf
+++ b/terraform/modules/batch_notification_processor/main.tf
@@ -41,6 +41,9 @@ resource "aws_lambda_function" "batch_notification_processor" {
       ENVIRONMENT     = var.environment
       OAUTH_TOKEN_URL = local.secrets["oauth_token_url"]
       REGION_NAME     = var.region
+
+      LAMBDA_STATUS_CHECK_ARN      = var.message_status_handler_lambda_arn
+      LAMBDA_STATUS_CHECK_ROLE_ARN = var.message_status_handler_lambda_role_arn
     }
   }
 

--- a/terraform/modules/batch_notification_processor/variables.tf
+++ b/terraform/modules/batch_notification_processor/variables.tf
@@ -24,6 +24,16 @@ variable "batch_notification_processor_lambda_role_arn" {
   description = "ARN for the batch processor lambda role"
 }
 
+variable "message_status_handler_lambda_arn" {
+  type        = string
+  description = "ARN for the message status handler lambda function"
+}
+
+variable "message_status_handler_lambda_role_arn" {
+  type        = string
+  description = "ARN for the message status handler lambda role"
+}
+
 variable "subnet_ids" {
   type        = list(string)
   description = "Ids for subnets"


### PR DESCRIPTION
Adding message status handler / role ARNs allows us to schedule the message status handler function from the batch notification processor function.