### PR TITLE
Include shared code in zip archives we deploy via CI/CD

### DIFF
--- a/.github/workflows/deploy-batch-notification-processor.yml
+++ b/.github/workflows/deploy-batch-notification-processor.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install zip tool
         uses: montudor/action-zip@v1
       - name: Create zip file for Lambda function
-        run: cd batch_notification_processor && zip -r code.zip .
+        run: cd batch_notification_processor && cp ../shared/*.py . && zip -r code.zip .
       - name: AWS CLI v2
         uses: imehedi/actions-awscli-v2@latest
         with:

--- a/.github/workflows/deploy-message-status-handler.yml
+++ b/.github/workflows/deploy-message-status-handler.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install zip tool
         uses: montudor/action-zip@v1
       - name: Create zip file for Lambda function
-        run: cd message_status_handler && zip -r code.zip .
+        run: cd message_status_handler && cp ../shared/*.py . && zip -r code.zip .
       - name: AWS CLI v2
         uses: imehedi/actions-awscli-v2@latest
         with:


### PR DESCRIPTION
When we merge code to main, we update the lambdas (currently this does not include dependency changes in Pipfile)
Ensure that common code in the `shared/` directory is included in the lambda zips we build in the CI/CD pipeline.